### PR TITLE
Introduce epics for side effects STCON-16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-connect
 
+## 2.5.0 IN PROGRESS
+
+* Introduce side effects. Fixes STRIPES-394.
+
 ## [2.4.0](https://github.com/folio-org/stripes-connect/tree/v2.4.0) (2017-07-11)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v2.3.0...v2.4.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.5.0 IN PROGRESS
 
-* Introduce side effects. Fixes STRIPES-394.
+* Introduce side effects. Fixes STCON-16.
 
 ## [2.4.0](https://github.com/folio-org/stripes-connect/tree/v2.4.0) (2017-07-11)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v2.3.0...v2.4.0)

--- a/OkapiResource.js
+++ b/OkapiResource.js
@@ -38,5 +38,20 @@ const defaults = {
 export default class OkapiResource extends RESTResource {
   constructor(name, query = {}, module = null, logger, dataKey) {
     super(name, query, module, logger, dataKey, defaults);
+    this.visibleCount = 0;
+  }
+
+  markVisible() {
+    this.visibleCount += 1;
+  }
+
+  markInvisible() {
+    if (this.visibleCount > 0) {
+      this.visibleCount -= 1;
+    }
+  }
+
+  isVisible() {
+    return this.visibleCount > 0;
   }
 }

--- a/RESTResource.js
+++ b/RESTResource.js
@@ -385,6 +385,13 @@ export default class RESTResource {
   refresh(dispatch, props) {
     if (this.optionsTemplate.fetch === false) return;
     if (props.dataKey === this.dataKey) dispatch(this.fetchAction(props));
+    this.dispatch = dispatch;
+    this.cachedProps = { ...props, sync: true };
+  }
+
+  sync() {
+    if (!this.dispatch || !this.cachedProps) return;
+    this.dispatch(this.fetchAction(this.cachedProps));
   }
 
   createAction = (record, props) => {
@@ -510,7 +517,7 @@ export default class RESTResource {
       if (url === null) return null;
       const { headers, records } = options;
       // noop if the URL and recordsRequired didn't change
-      if (url === this.lastUrl && options.recordsRequired === this.lastReqd) return null;
+      if (!props.sync && url === this.lastUrl && options.recordsRequired === this.lastReqd) return null;
       this.lastUrl = url;
       this.lastReqd = options.recordsRequired;
 

--- a/epics/index.js
+++ b/epics/index.js
@@ -1,0 +1,2 @@
+export * from './mutations';
+export * from './refresh';

--- a/epics/mutations.js
+++ b/epics/mutations.js
@@ -4,7 +4,7 @@ const actionNames = [
   'DELETE_SUCCESS',
 ];
 
-// returns list of epics which execute (and dispatch REFRESH)
+// returns list of epics which execute
 // after mutation happens on a given resource
 export function mutationEpics(resource) {
   const actionPrefix = resource.crudName.toUpperCase();

--- a/epics/mutations.js
+++ b/epics/mutations.js
@@ -1,0 +1,24 @@
+const actionNames = [
+  'CREATE_SUCCESS',
+  'UPDATE_SUCCESS',
+  'DELETE_SUCCESS',
+];
+
+// returns list of epics which execute (and dispatch REFRESH)
+// after mutation happens on a given resource
+export function mutationEpics(resource) {
+  const actionPrefix = resource.crudName.toUpperCase();
+  const options = resource.optionsTemplate;
+
+  return actionNames.map(name =>
+    (action$) => action$
+      .ofType(`${actionPrefix}_${name}`)
+      .debounceTime(100)
+      .map(action => {
+        const path = options.path.replace(/[\/].*$/g, '');
+        const name = resource.name;
+        const meta = Object.assign({}, action.meta, { path, name });
+        return { ...action, meta, type: 'REFRESH' };
+      })
+  );
+}

--- a/epics/refresh.js
+++ b/epics/refresh.js
@@ -1,0 +1,22 @@
+import 'rxjs/add/operator/map';
+
+// returns epic which executes after refresh action
+// and syncs/refreshes given resource
+export function refreshEpic(resource) {
+  return (action$) => action$
+    .ofType('REFRESH')
+    .map(action => {
+      const { name, path } = action.meta;
+      const resPath = resource.optionsTemplate.path || '';
+
+      console.log(name, path, resPath, resPath.startsWith(path), resource.isVisible());
+      if (
+        resource.isVisible() &&
+        resource.name != name &&
+        resPath.startsWith(path)) {
+        resource.sync();
+      }
+      return { ...action, type: 'REFRESH_SUCCESS' };
+    })
+}
+

--- a/epics/refresh.js
+++ b/epics/refresh.js
@@ -9,7 +9,6 @@ export function refreshEpic(resource) {
       const { name, path } = action.meta;
       const resPath = resource.optionsTemplate.path || '';
 
-      console.log(name, path, resPath, resPath.startsWith(path), resource.isVisible());
       if (
         resource.isVisible() &&
         resource.name != name &&

--- a/epics/refresh.js
+++ b/epics/refresh.js
@@ -1,6 +1,6 @@
 import 'rxjs/add/operator/map';
 
-// returns epic which executes after refresh action
+// returns epic which executes after a refresh action
 // and syncs/refreshes given resource
 export function refreshEpic(resource) {
   return (action$) => action$

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-connect",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Declarative REST data access for React components",
   "repository": "folio-org/stripes-connect",
   "publishConfig": {
@@ -42,6 +42,7 @@
     "redux-thunk": "^2.1.0"
   },
   "dependencies": {
+    "@folio/stripes-redux": "^1.0.0",
     "isomorphic-fetch": "^2.2.1",
     "lodash": "^4.17.2",
     "query-string": "^4.3.2",
@@ -50,6 +51,7 @@
     "react-redux": "^5.0.2",
     "redux": "^3.6.0",
     "redux-crud": "^3.0.0",
+    "rxjs": "^5.4.2",
     "uuid": "^3.0.1"
   }
 }


### PR DESCRIPTION
This PR introduces epics (side effects) in order to sync mutations with refresh. 
Here are couple details about the current setup:

* They refresh related resources after mutation happens
* The resources which will be refreshed have to be visible and match the path of the resource from where the mutation originates.