### PR TITLE
Prop types deprecation warning

### DIFF
--- a/connect.js
+++ b/connect.js
@@ -5,6 +5,7 @@ import OkapiResource from './OkapiResource';
 import RESTResource from './RESTResource';
 import LocalResource from './LocalResource';
 import { mutationEpics, refreshEpic } from './epics';
+import PropTypes from 'prop-types';
 
 /* eslint-env browser */
 
@@ -21,20 +22,20 @@ const wrap = (Wrapped, module, epics, logger) => {
 
   class Wrapper extends React.Component {
     static propTypes = {
-      refreshRemote: React.PropTypes.func.isRequired,
+      refreshRemote: PropTypes.func.isRequired,
       // We use it, but via ...props, so:
       // eslint-disable-next-line react/no-unused-prop-types
-      location: React.PropTypes.shape({
-        hostname: React.PropTypes.string, // First two are not defined in some parts of lifecyle
-        port:     React.PropTypes.string,
-        pathname: React.PropTypes.string.isRequired,
-        search:   React.PropTypes.string.isRequired,
-        hash:     React.PropTypes.string.isRequired,
+      location: PropTypes.shape({
+        hostname: PropTypes.string, // First two are not defined in some parts of lifecyle
+        port:     PropTypes.string,
+        pathname: PropTypes.string.isRequired,
+        search:   PropTypes.string.isRequired,
+        hash:     PropTypes.string.isRequired,
         // query: null
         // state: null
       }),
-      data: React.PropTypes.object, // eslint-disable-line react/forbid-prop-types
-      dataKey: React.PropTypes.string,
+      data: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+      dataKey: PropTypes.string,
     };
 
     constructor(props, context) {
@@ -153,8 +154,8 @@ const wrap = (Wrapped, module, epics, logger) => {
   }
 
   Wrapper.contextTypes = {
-    addReducer: React.PropTypes.func,
-    store: React.PropTypes.object,
+    addReducer: PropTypes.func,
+    store: PropTypes.object,
   };
 
   Wrapper.mapState = (state, ownProps) => {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "dependencies": {
     "isomorphic-fetch": "^2.2.1",
     "lodash": "^4.17.2",
+    "prop-types": "^15.5.10",
     "query-string": "^5.0.0",
     "react": "^15.5.1",
     "react-dom": "^15.4.0",

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "jsdom": "^11.0.0",
     "jsdom-global": "^3.0.2",
     "mocha": "^3.1.2",
-    "react-addons-test-utils": "^15.4.0",
     "react-router": "^4.0.0",
+    "react-test-renderer": "^15.6.1",
     "redux-thunk": "^2.1.0"
   },
   "dependencies": {


### PR DESCRIPTION
Removes two warnings:

`Warning: Accessing PropTypes via the main React package is deprecated, and will be removed in  React v16.0. Use the latest available v15.* prop-types package from npm instead. For info on usage, compatibility, migration and more, see` https://fb.me/prop-types-docs

and 

`Warning: ReactTestUtils has been moved to react-dom/test-utils. Update references to remove this warning.`
