### PR TITLE
Consistent store prefix for local resources STCON-36

### DIFF
--- a/LocalResource.js
+++ b/LocalResource.js
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+
 export default class LocalResource {
   constructor(name, query = {}, module = null, logger, dataKey) {
     this.name = name;
@@ -39,7 +41,7 @@ export default class LocalResource {
     },
   })
 
-  stateKey = () => `${this.dataKey ? `${this.dataKey}#` : ''}${this.module}-${this.name}`;
+  stateKey = () => `${this.dataKey ? `${this.dataKey}#` : ''}${_.snakeCase(this.module)}_${this.name}`;
 
   reducer = (state = {}, action) => {
     if (action.meta !== undefined &&

--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -87,7 +87,7 @@ function mockProps(state, module, dataKey) {
 
     if (rawKey) {
       // console.log(`    considering rawKey ${rawKey}`);
-      const re = new RegExp(`^${module}.(.*)`);
+      const re = new RegExp(`^${_.snakeCase(module)}.(.*)`);
       const res = re.exec(rawKey);
       if (Array.isArray(res) && res.length > 1) {
         mock.data[res[1]] = state[key];

--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -465,6 +465,7 @@ export default class RESTResource {
     const key = this.stateKey();
     return (dispatch, getState) => {
       const options = this.verbOptions('GET', getState(), props);
+      if (options === null) return null; // needs dynamic parts that aren't available
       const url = urlFromOptions(options);
       if (url === null) return null;
       const { headers, records } = options;


### PR DESCRIPTION
Not only more consistent, this should make all resources accessible from manifest functions so we can use them for things like client side joins.