### PR TITLE
Adjust mutations epic. Fixes STCOR-88

### DIFF
--- a/epics/mutations.js
+++ b/epics/mutations.js
@@ -7,7 +7,6 @@ const actionNames = [
 // returns list of epics which execute
 // after mutation happens on a given resource
 export function mutationEpics(resource) {
-  const actionPrefix = resource.crudName.toUpperCase();
   const options = resource.optionsTemplate;
 
   return actionNames.map(name =>

--- a/epics/mutations.js
+++ b/epics/mutations.js
@@ -12,7 +12,7 @@ export function mutationEpics(resource) {
 
   return actionNames.map(name =>
     (action$) => action$
-      .ofType(`${actionPrefix}_${name}`)
+      .ofType(`@@stripes-connect/${name}`)
       .map(action => {
         const path = options.path && options.path.replace(/[\/].*$/g, '');
         const name = resource.name;


### PR DESCRIPTION
Since redux-crud is gone and we are following a new pattern for action names the mutations epic has to be adjusted.