### PR TITLE
 Initial work on "accumulate" manifest option with "GET" action STCON-33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change history for stripes-connect
 
+## IN PROGRESS[3.0.0](https://github.com/folio-org/stripes-connect/tree/v3.0.0) (2017-)
+[Full Changelog](https://github.com/folio-org/stripes-connect/compare/v2.7.0...v3.0.0)
+
+* Remove `props.data`, resources are now exclusively accessed via `props.resources`. STCON-22.
+* Replace redux-crud with our own actions and reducer. STCON-15.
+* Consistent redux store prefix for local resources. STCON-36.
+* `accumulate` manifest option to enable explicit GET actions. STCON-33. 
+
+
 ## [2.7.0](https://github.com/folio-org/stripes-connect/tree/v2.7.0) (2017-09-01)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v2.6.0...v2.7.0)
 

--- a/RESTResource/actionCreatorsFor.js
+++ b/RESTResource/actionCreatorsFor.js
@@ -37,6 +37,8 @@ export default function actionCreatorsFor(resource) {
 
     fetchSuccess: passMetaPayload('FETCH_SUCCESS'),
 
+    accFetchSuccess: passMetaPayload('ACC_FETCH_SUCCESS'),
+
     fetchError: passPayload('FETCH_ERROR'),
 
     pagingStart: () => ({
@@ -51,5 +53,10 @@ export default function actionCreatorsFor(resource) {
     }),
 
     pageSuccess: passMetaPayload('PAGE_SUCCESS'),
+
+    reset: () => ({
+      type: '@@stripes-connect/RESET',
+      meta: commonMeta,
+    }),
   };
 }

--- a/RESTResource/reducer.js
+++ b/RESTResource/reducer.js
@@ -33,6 +33,22 @@ export default function (state = initialResourceState, action) {
         ...action.meta,
       });
     }
+    case '@@stripes-connect/ACC_FETCH_SUCCESS': {
+      let records;
+      if (Array.isArray(action.payload)) records = [...state.records, ...action.payload];
+      else records = [...state.records, _.clone(action.payload)];
+      return Object.assign({}, state, {
+        hasLoaded: true,
+        loadedAt: new Date(),
+        isPending: false,
+        failed: false,
+        records,
+        ...action.meta,
+      });
+    }
+    case '@@stripes-connect/RESET': {
+      return initialResourceState;
+    }
     case '@@stripes-connect/CREATE_SUCCESS': {
       return Object.assign({}, state, {
         successfulMutations: [{


### PR DESCRIPTION
# An option for Okapi resources to accumulate records

If you set `accumulate: true` in your manifest, stripes-connect will offer
two additional actions on the (soon to be moved/renamed) props.mutator
object: `GET()` and `reset()`. It will also no longer automatically fetch
any records, instead, you trigger a fetch by calling GET and any records
returned are appended to the resource. It returns a promise that resolves to
an array of records. Optionally, you can specify a parameter in the same
format as the manifest options (eg. `{ path: 'users'   params: { query:
'water' } }`). reset() clears the resource.