### PR TITLE
Address reconnecting issues. Fixes STCON-40

### DIFF
--- a/connect.js
+++ b/connect.js
@@ -16,9 +16,17 @@ const types = {
   rest: RESTResource,
 };
 
-const wrap = (Wrapped, module, epics, logger) => {
+const wrap = (Wrapped, module, epics, logger, options = {}) => {
   const resources = [];
-  const resourceRegister = {}; // map of resource names to resource objects
+  const dataKey = options.dataKey;
+
+  _.map(Wrapped.manifest, (query, name) => {
+    const resource = new types[query.type || defaultType](name, query, module, logger, dataKey);
+    resources.push(resource);
+    if (query.type === 'okapi') {
+      epics.add(...mutationEpics(resource), refreshEpic(resource));
+    }
+  });
 
   class Wrapper extends React.Component {
     static propTypes = {
@@ -34,7 +42,6 @@ const wrap = (Wrapped, module, epics, logger) => {
         // query: null
         // state: null
       }),
-      data: PropTypes.object, // eslint-disable-line react/forbid-prop-types
       resources: PropTypes.object, // eslint-disable-line react/forbid-prop-types
       dataKey: PropTypes.string,
     };
@@ -44,21 +51,6 @@ const wrap = (Wrapped, module, epics, logger) => {
       this.context = context;
       this.logger = logger;
       Wrapper.logger = logger;
-
-      // this.resources = []; // references to a subset of class-level resources
-      _.forOwn(Wrapped.manifest, (query, name) => {
-        // Regular manifest entries describe resources
-        const dk = props.dataKey;
-        const dkName = `${name}${dk === undefined ? '' : `-${dk}`}`;
-        if (!resourceRegister[dkName]) {
-          const resource = new types[query.type || defaultType](name, query, module, logger, props.dataKey);
-          resources.push(resource);
-          resourceRegister[dkName] = resource;
-          if (query.type === 'okapi') {
-            epics.add(...mutationEpics(resource), refreshEpic(resource));
-          }
-        }
-      });
       logger.log('connect-lifecycle', `constructed <${Wrapped.name}>, resources =`, resources);
     }
 
@@ -81,7 +73,6 @@ const wrap = (Wrapped, module, epics, logger) => {
             store.dispatch(resource.actions.fetchSuccess(paging[paging.length - 1].meta, records));
           };
           const onPageChange = (paging) => {
-            // console.log("MOO", paging);
             const allDone = paging.reduce((acc, val) => acc && val.isComplete, true);
             if (allDone && paging.length > 0) onPageSuccess(paging);
           };
@@ -158,42 +149,28 @@ const wrap = (Wrapped, module, epics, logger) => {
     store: PropTypes.object,
   };
 
-  Wrapper.mapState = (state, ownProps) => {
-    const data = {};
+  Wrapper.mapState = (state) => {
     logger.log('connect-lifecycle', `mapState for <${Wrapped.name}>, resources =`, resources);
+
     const resourceData = {};
     for (const r of resources) {
-      if (r.dataKey === ownProps.dataKey) {
+      if (r.dataKey === dataKey) {
         resourceData[r.name] = Object.freeze(_.get(state, [`${r.stateKey()}`], null));
       }
     }
 
-    const newProps = { data, resources: resourceData };
+    const newProps = { dataKey, resources: resourceData };
     // TODO Generalise this into a pass-through option on connectFor
     if (typeof state.okapi === 'object') newProps.okapi = state.okapi;
 
     return newProps;
   };
 
-  // This seems to get called only _before_ the constructor, so does
-  // not see the resources that have been added at construction. So
-  // all we do is stash the dispatch function, and leave the
-  // mergeProps function (which gets called after each mapState) to
-  // use it to do the real dispatch-mapping.
-  //
-  Wrapper.mapDispatch = (dispatch) => {
-    logger.log('connect-lifecycle', `mapDispatch for <${Wrapped.name}>, resources =`, resources);
-    return { dispatch };
-  };
-
-  Wrapper.mergeProps = (stateProps, dispatchProps, ownProps) => {
-    const dispatch = dispatchProps.dispatch;
-    logger.log('connect-lifecycle', `mergeProps for <${Wrapped.name}>, resources =`, resources);
+  Wrapper.mapDispatch = (dispatch, ownProps) => {
     const res = {};
-
     res.mutator = {};
     for (const r of resources) {
-      if (r.dataKey === ownProps.dataKey) {
+      if (r.dataKey === dataKey) {
         res.mutator[r.name] = r.getMutator(dispatch, ownProps);
       }
     }
@@ -207,7 +184,7 @@ const wrap = (Wrapped, module, epics, logger) => {
       });
     };
 
-    return Object.assign({}, ownProps, stateProps, res);
+    return res;
   };
 
   return Wrapper;
@@ -218,18 +195,18 @@ defaultLogger.log = (cat, ...args) => {
   console.log(`stripes-connect (${cat})`, ...args);
 };
 
-export const connect = (Component, module, epics, loggerArg) => {
+export const connect = (Component, module, epics, loggerArg, options) => {
   const logger = loggerArg || defaultLogger;
   if (typeof Component.manifest === 'undefined') {
     logger.log('connect-no', `not connecting <${Component.name}> for '${module}': no manifest`);
     return Component;
   }
   logger.log('connect', `connecting <${Component.name}> for '${module}'`);
-  const Wrapper = wrap(Component, module, epics, logger);
+  const Wrapper = wrap(Component, module, epics, logger, options);
   const Connected = reduxConnect(Wrapper.mapState, Wrapper.mapDispatch, Wrapper.mergeProps)(Wrapper);
   return Connected;
 };
 
-export const connectFor = (module, epics, logger) => Component => connect(Component, module, epics, logger);
+export const connectFor = (module, epics, logger) => (Component, options) => connect(Component, module, epics, logger, options);
 
 export default connect;

--- a/test/integration.js
+++ b/test/integration.js
@@ -6,14 +6,12 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { createStore, applyMiddleware, compose, combineReducers } from 'redux';
 import { Provider } from 'react-redux';
-import { StaticRouter } from 'react-router';
 import thunk from 'redux-thunk';
 import fetchMock from 'fetch-mock';
 
 import connect from '../connect';
 
 chai.should();
-const routerContext = {};
 
 // Provide a redux store and addReducer() function in context
 let reducers = { okapi: (state = {}) => state };
@@ -35,9 +33,7 @@ class Root extends Component {
     const { component:ToTest } = this.props;
     return (
       <Provider store={this.props.store}>
-        <StaticRouter context={routerContext} location="/">
-          <ToTest {...this.props} />
-        </StaticRouter>
+        <ToTest {...this.props} />
       </Provider>
     );
   }

--- a/test/integration.js
+++ b/test/integration.js
@@ -345,12 +345,12 @@ describe('connect()', () => {
     inst.setProps({ showChild: true });
 
     // These should be still present
-    //inst.find(Child2).props().resources.should.have.property('childResource2');
-    //inst.find(Child2).props().mutator.should.have.property('childResource2');
+    inst.find(Child2).props().resources.should.have.property('childResource2');
+    inst.find(Child2).props().mutator.should.have.property('childResource2');
 
     // instead we are getting these
-    inst.find(Child2).props().resources.should.eql({});
-    inst.find(Child2).props().mutator.should.eql({});
+    //inst.find(Child2).props().resources.should.eql({});
+    //inst.find(Child2).props().mutator.should.eql({});
   });
 
 });


### PR DESCRIPTION
This PR addresses the issue discovered in [STCON-40](https://issues.folio.org/browse/STCON-40). The biggest change is the place where the resources are being initialized (inside the `wrap` function). 

The side effect of this refactoring causes the `dataKey` to be present when the connection happens. Because of that a new param had to be introduced  to `connect` called `options` which can be used to pass a `dataKey`. 

What it means in practice is that instead of doing this:

```js
constructor(props) {
  super();
  this.connectedAbout = props.stripes.connect(About);
}

render() {
  return (
    <div>
      <this.connectedAbout stripes={this.props.stripes} dataKey="1" />
      <this.connectedAbout stripes={this.props.stripes} dataKey="2" />
    </div>
  );
}
```
we will need to do this:

```js
constructor(props) {
  super();
  this.connectedAbout1 = props.stripes.connect(About, { dataKey: "1" });
  this.connectedAbout2 = props.stripes.connect(About, { dataKey: "2" });
}

render() {
  return (
    <div>
      <this.connectedAbout1 stripes={this.props.stripes} />
      <this.connectedAbout2 stripes={this.props.stripes} />
    </div>
  );
}
`

