### PR TITLE
Remove last vestiges of props.data 

### DIFF
--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -67,7 +67,7 @@ function processFallback(s, getPath, props) {
 // If we restructure the state into a per-module hierarchy we
 // won't need to go through this dance STRIPES-238
 function mockProps(state, module, dataKey) {
-  const mock = { resources: {}, data: {} };
+  const mock = { resources: {} };
   // console.log(` mockprops(${dataKey})`);
   Object.keys(state).forEach((key) => {
     // console.log(`  considering ${key}`);
@@ -89,8 +89,6 @@ function mockProps(state, module, dataKey) {
       const re = new RegExp(`^${_.snakeCase(module)}.(.*)`);
       const res = re.exec(rawKey);
       if (Array.isArray(res) && res.length > 1) {
-        // TODO: .data is temporary just to aid transition
-        mock.data[res[1]] = state[key];
         mock.resources[res[1]] = state[key];
         // console.log(`     added mock[${res[1]}] = ${state[key]}`);
       }

--- a/connect.js
+++ b/connect.js
@@ -8,7 +8,6 @@ import LocalResource from './LocalResource';
 import { mutationEpics, refreshEpic } from './epics';
 
 /* eslint-env browser */
-
 const defaultType = 'local';
 const types = {
   local: LocalResource,
@@ -34,7 +33,6 @@ const wrap = (Wrapped, module, epics, logger) => {
         // query: null
         // state: null
       }),
-      data: PropTypes.object, // eslint-disable-line react/forbid-prop-types
       resources: PropTypes.object, // eslint-disable-line react/forbid-prop-types
       dataKey: PropTypes.string,
     };
@@ -159,7 +157,6 @@ const wrap = (Wrapped, module, epics, logger) => {
   };
 
   Wrapper.mapState = (state, ownProps) => {
-    const data = {};
     logger.log('connect-lifecycle', `mapState for <${Wrapped.name}>, resources =`, resources);
     const resourceData = {};
     for (const r of resources) {
@@ -168,10 +165,9 @@ const wrap = (Wrapped, module, epics, logger) => {
       }
     }
 
-    const newProps = { data, resources: resourceData };
+    const newProps = { resources: resourceData };
     // TODO Generalise this into a pass-through option on connectFor
     if (typeof state.okapi === 'object') newProps.okapi = state.okapi;
-
     return newProps;
   };
 


### PR DESCRIPTION
This is necessary for my trivial graphql demos as Apollo client defaults to props.data.

While I can't get the full integration suite running locally, this change doesn't make things worse near as I can tell---17 failures from CI npms, 4 failures linking stripes-connect with this change, 8 failures when I check out master on the linked stripes-connect and 8 failures again when I check this branch back out.