### PR TITLE
Add logging for mockProps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 * Remove `props.data`, resources are now exclusively accessed via `props.resources`. STCON-22.
 * Replace redux-crud with our own actions and reducer. STCON-15.
 * Consistent redux store prefix for local resources. STCON-36.
-* `accumulate` manifest option to enable explicit GET actions. STCON-33. 
-
+* `accumulate` manifest option to enable explicit GET actions. STCON-33.
+* Add logging for `mockProps` (using category `"mock"`). Needed to debug UIORG-38.
 
 ## [2.7.0](https://github.com/folio-org/stripes-connect/tree/v2.7.0) (2017-09-01)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v2.6.0...v2.7.0)

--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -236,7 +236,7 @@ export default class RESTResource {
           substitute(param, props, state, this.module, this.logger));
       } else if (typeof options.params === 'function') {
         const parsedQuery = queryString.parse(_.get(props, ['location', 'search']));
-        options.params = options.params(parsedQuery, _.get(props, ['match', 'params']), mockProps(state, module, props.dataKey, logger).data, this.logger);
+        options.params = options.params(parsedQuery, _.get(props, ['match', 'params']), mockProps(state, module, props.dataKey, this.logger).data, this.logger);
       }
 
       // recordsRequired


### PR DESCRIPTION
Uses new logging category `mock`.

(Requires an additional argument to `mockProps`, a logger object. These function signatures are getting big, suggesting that more stuff should go into the resouce objects, accessible via `this`.)

I need this to have some hope of getting to the bottom of UIORG-38.
