### PR TITLE
STCON-39 Added the ability to define the resourceShouldRefresh

### DIFF
--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -466,16 +466,9 @@ export default class RESTResource {
         if (!props.sync && url === this.lastUrl && options.recordsRequired === this.lastReqd) return null;
       } else {
         // Check if resourceShouldRefresh is a boolean or function
-        if (_.isBoolean(resourceShouldRefresh)) {
-          if (!resourceShouldRefresh) return null;
-        } else if (_.isFunction(resourceShouldRefresh)) {
-          // Function should return a boolean!
-          if (!resourceShouldRefresh()) return null;
-        } else {
-          // If not a function or boolean should return error or maintain consistency with prior functionality?
-          // Currently, does not return error, will maintain prior functionality.
-          if (!props.sync && url === this.lastUrl && options.recordsRequired === this.lastReqd) return null;
-        }
+        if (_.isBoolean(resourceShouldRefresh) && !resourceShouldRefresh) return null;
+        // Function should return a boolean!
+        if (_.isFunction(resourceShouldRefresh) && !resourceShouldRefresh()) return null;
       }
       this.lastUrl = url;
       this.lastReqd = options.recordsRequired;

--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -459,22 +459,22 @@ export default class RESTResource {
       const url = urlFromOptions(options);
       if (url === null) return null;
       const { headers, records, resourceShouldRefresh } = options;
-      //Check for existence of resourceShouldRefresh
-      if(_.isUndefined(resourceShouldRefresh)){
-        //Maintain backward compatability if undefined maintin code
+      // Check for existence of resourceShouldRefresh
+      if (_.isUndefined(resourceShouldRefresh)) {
+        // Maintain backward compatability if undefined maintin code
         // noop if the URL and recordsRequired didn't change
-        if (!props.sync && url === this.lastUrl && options.recordsRequired === this.lastReqd)return null;
-      }else{
-        //Check if resourceShouldRefresh is a boolean or funciton
-        if (_.isBoolean(resourceShouldRefresh)){
-          if(!resourceShouldRefresh)return null;
-        }else if(_.isFunction(resourceShouldRefresh)){
-          //Function should return a boolean!
-          if(!resourceShouldRefresh())return null;
-        }else{
-          //If not a function or boolean should return error or maintain consistency with prior functionality?
-          //Currently, does not return error, will maintain prior functionality.
-          if (!props.sync && url === this.lastUrl && options.recordsRequired === this.lastReqd)return null;
+        if (!props.sync && url === this.lastUrl && options.recordsRequired === this.lastReqd) return null;
+      } else {
+        // Check if resourceShouldRefresh is a boolean or function
+        if (_.isBoolean(resourceShouldRefresh)) {
+          if (!resourceShouldRefresh) return null;
+        } else if (_.isFunction(resourceShouldRefresh)) {
+          // Function should return a boolean!
+          if (!resourceShouldRefresh()) return null;
+        } else {
+          // If not a function or boolean should return error or maintain consistency with prior functionality?
+          // Currently, does not return error, will maintain prior functionality.
+          if (!props.sync && url === this.lastUrl && options.recordsRequired === this.lastReqd) return null;
         }
       }
       this.lastUrl = url;


### PR DESCRIPTION
STCON-39: Added the ability to define the resourceShouldRefresh as a boolean or a function. The function should return a boolean. I have coded to maintain backward compatibility. If resourceShouldRefresh is not set it will default to prior functionality.

@MikeTaylor @mkuklis Please take a look and review.  Thanks Mark

I have tested code against UIU-248. I will also submit pull request for UIU-248(ui-users). 