### PR TITLE
Exporting compilePathTemplate function

### DIFF
--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -149,12 +149,7 @@ function urlFromOptions(options, pk) {
   return path;
 }
 
-// Implements dynamic manifest components with ?{syntax}. Namespaces so far:
-// ? - query parameters in current url
-// : - path components as defined by react-router
-// $ - resources
-// ! - properties
-//
+
 // This now takes so many arguments that it really ought to be a
 // method of RESTResource rather than a standalone function that is
 // passed various parts of the RESTResource object. But since it's
@@ -163,48 +158,59 @@ function urlFromOptions(options, pk) {
 //
 export function substitute(original, props, state, module, logger, dataKey) {
   const parsedQuery = queryString.parse(_.get(props, ['location', 'search']));
-  let dynamicPartsSatisfied = true;
   let result;
-
+  let localProps = mockProps(state, module, props.dataKey || dataKey, logger).resources;
   if (typeof original === 'function') {
     // Call back to resource-specific code
-    result = original(parsedQuery, _.get(props, ['match', 'params']), mockProps(state, module, props.dataKey || dataKey, logger).resources, logger);
-    dynamicPartsSatisfied = (result !== null);
+    result = original(parsedQuery, _.get(props, ['match', 'params']), localProps, logger);
   } else if (typeof original === 'string') {
     // eslint-disable-next-line consistent-return
-    result = original.replace(/([?:$%!]){(.*?)}/g, (match, ns, name) => {
-      switch (ns) { // eslint-disable-line default-case
-        case '?': {
-          const queryParam = processFallback(name, [], parsedQuery);
-          if (queryParam === null) dynamicPartsSatisfied = false;
-          return queryParam;
-        }
-        case ':': {
-          const pathComp = processFallback(name, ['match', 'params'], props);
-          if (pathComp === null) dynamicPartsSatisfied = false;
-          return pathComp;
-        }
-        case '%': case '$': {
-          const localState = processFallback(name.split('.'), ['resources'], mockProps(state, module, props.dataKey || dataKey, logger));
-          if (localState === null) dynamicPartsSatisfied = false;
-          return localState;
-        }
-        case '!': {
-          const prop = processFallback(name.split('.'), [], props);
-          if (prop === null) dynamicPartsSatisfied = false;
-          return prop;
-        }
-      }
-    });
+    result = compilePathTemplate(original, parsedQuery, props, localProps);
   } else {
     throw new Error('Invalid type passed to RESTResource.substitute()');
   }
 
   logger.log('substitute', `substitute(${
     (typeof original === 'function') ? '<FUNCTION>' : original
-  }) -> ${result}, satisfied=${dynamicPartsSatisfied}`);
-  return dynamicPartsSatisfied ? result : null;
+  }) -> ${result}, satisfied=${result!==null}`);
+
+  return result;
 }
+
+// Process string template with ?{syntax}. Namespaces so far:
+// ? - query parameters in current url
+// : - path components as defined by react-router
+// $ - resources
+// ! - properties
+export function compilePathTemplate(template, parsedQuery, props, localProps) {
+  let dynamicPartsSatisfied = true;
+  
+  let result = template.replace(/([?:$%!]){(.*?)}/g, (match, ns, name) => {
+    switch (ns) { // eslint-disable-line default-case
+      case '?': {
+        const queryParam = processFallback(name, [], parsedQuery);
+        if (queryParam === null) dynamicPartsSatisfied = false;
+        return queryParam;
+      }
+      case ':': {
+        const pathComp = processFallback(name, ['match', 'params'], props);
+        if (pathComp === null) dynamicPartsSatisfied = false;
+        return pathComp;
+      }
+      case '%': case '$': {
+        const localState = processFallback(name.split('.'), [], localProps);
+        if (localState === null) dynamicPartsSatisfied = false;
+        return localState;
+      }
+      case '!': {
+        const prop = processFallback(name.split('.'), [], props);
+        if (prop === null) dynamicPartsSatisfied = false;
+        return prop;
+      }
+    }
+  });
+  return dynamicPartsSatisfied ? result : null;
+};
 
 export default class RESTResource {
   constructor(name, query = {}, module = null, logger, dataKey, defaults = defaultDefaults) {

--- a/connect.js
+++ b/connect.js
@@ -184,6 +184,7 @@ const wrap = (Wrapped, module, epics, logger, options = {}) => {
 
 const defaultLogger = () => {};
 defaultLogger.log = (cat, ...args) => {
+  // eslint-disable-next-line no-console
   console.log(`stripes-connect (${cat})`, ...args);
 };
 


### PR DESCRIPTION
Resolves [STRIPES-480](https://issues.folio.org/browse/STRIPES-480)

Relates to PRs in

[ui-users](https://github.com/folio-org/ui-users/pull/253) and [stripes-components](https://github.com/folio-org/stripes-components/pull/251).

This exports the template compilation portion of the substitute function into a reusable exported function. It should be fully backwards compatible.