### PR TITLE
Allow dataKey in manifest

### DIFF
--- a/connect.js
+++ b/connect.js
@@ -20,7 +20,7 @@ const wrap = (Wrapped, module, epics, logger, options = {}) => {
   const dataKey = options.dataKey;
 
   _.map(Wrapped.manifest, (query, name) => {
-    const resource = new types[query.type || defaultType](name, query, module, logger, dataKey);
+    const resource = new types[query.type || defaultType](name, query, module, logger, query.dataKey || dataKey);
     resources.push(resource);
     if (query.type === 'okapi') {
       epics.add(...mutationEpics(resource), refreshEpic(resource));

--- a/connect.js
+++ b/connect.js
@@ -147,9 +147,7 @@ const wrap = (Wrapped, module, epics, logger, options = {}) => {
 
     const resourceData = {};
     for (const r of resources) {
-      if (r.dataKey === dataKey) {
-        resourceData[r.name] = Object.freeze(_.get(state, [`${r.stateKey()}`], null));
-      }
+      resourceData[r.name] = Object.freeze(_.get(state, [`${r.stateKey()}`], null));
     }
 
     const newProps = { dataKey, resources: resourceData };
@@ -162,9 +160,7 @@ const wrap = (Wrapped, module, epics, logger, options = {}) => {
     const res = {};
     res.mutator = {};
     for (const r of resources) {
-      if (r.dataKey === dataKey) {
-        res.mutator[r.name] = r.getMutator(dispatch, ownProps);
-      }
+      res.mutator[r.name] = r.getMutator(dispatch, ownProps);
     }
 
     res.refreshRemote = (params) => {


### PR DESCRIPTION
Currently `dataKey` can only be passed in `options` object. With this PR, it can be set in the manifest per resource. 