### PR TITLE
RESTResource: Prevent trying to use cached response from aborted requests

### DIFF
--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -474,10 +474,16 @@ export default class RESTResource {
       const options = this.verbOptions('GET', getState(), props);
       if (options === null) {
         dispatch(this.actions.fetchAbort({ message: 'cannot satisfy request: missing query?' }));
+        this.lastUrl = null;
         return null; // needs dynamic parts that aren't available
       }
+
       const url = urlFromOptions(options);
-      if (url === null) return null;
+      if (url === null) {
+        this.lastUrl = null;
+        return null;
+      }
+
       const { headers, records, resourceShouldRefresh } = options;
       // Check for existence of resourceShouldRefresh
       if (_.isUndefined(resourceShouldRefresh)) {


### PR DESCRIPTION
This is part of the fixes to [UIU-466.](https://issues.folio.org/browse/UIU-466)

The underlying bug has probably been happening for a while, ever since the ability to abort requests from inside `makeQueryFunction` was added. Basically, you'd do something like the following: 

- Open Users, toggle the Active filter to checked. We fetch the list of users and set the `lastUrl` and cache the response.
- Toggle the Active filter to unchecked. We do not fetch the list of users because we require a query or filters, but do update the lastUrl.
- Open Settings, a module which doesn't fetch anything immediately anymore.
- Switch back to Users. We're probably in an unstable state now. If we aren't, toggle back to Settings and then back to Users again. We attempt to fetch, notice it's the same as lastUrl and start using the cache contents (which is the list of Active users). 
- This process has freaked the MCLRenderer out somehow as well during the process and it tries to divide by zero so it doesn't re-render the list of users, but you can see we're using the cached records because the header states "xxx Records found". [That is prevented against in this PR.](https://github.com/folio-org/stripes-components/pull/327)