### PR TITLE
Stcon 65 allow other falsey init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * `verbOptions` returns null if any of the templated values are incomplete. Fixes STCON-58.
 * Failed fetches on a resource clear existing data from that resource. Fixes STCON-64. Available from v3.1.1.
+* Added ability to specify `throwErrors` boolean in resource manifests. Setting to `false` turns off global error reporting for that resource. Available from v3.1.2.
 
 ## [3.1.0](https://github.com/folio-org/stripes-connect/tree/v3.1.0) (2018-01-09)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v3.0.0...v3.1.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * `verbOptions` returns null if any of the templated values are incomplete. Fixes STCON-58.
 * Failed fetches on a resource clear existing data from that resource. Fixes STCON-64. Available from v3.1.1.
 * Added ability to specify `throwErrors` boolean in resource manifests. Setting to `false` turns off global error reporting for that resource. Available from v3.1.2.
+* Allow LocalResource to be initalized with a non-object falsey value. Refs STCON-65. Available from v3.1.3.
 
 ## [3.1.0](https://github.com/folio-org/stripes-connect/tree/v3.1.0) (2018-01-09)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v3.0.0...v3.1.0)

--- a/LocalResource.js
+++ b/LocalResource.js
@@ -36,7 +36,7 @@ export default class LocalResource {
 
   stateKey = () => `${this.dataKey ? `${this.dataKey}#` : ''}${_.snakeCase(this.module)}_${this.name}`;
 
-  reducer = (state = this.query.initialValue ? this.query.initialValue : {}, action) => {
+  reducer = (state = this.query.initialValue !== undefined ? this.query.initialValue : {}, action) => {
     if (action.meta !== undefined &&
         action.meta.module === this.module &&
         action.meta.resource === this.name &&

--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -207,6 +207,7 @@ export default class RESTResource {
     this.crudName = module ? `${_.snakeCase(module)}_${_.snakeCase(name)}` : _.snakeCase(name);
     this.optionsTemplate = _.merge({}, defaults, query);
     this.optionsFromState = query.optionsFromState || (() => undefined);
+    this.throwErrors = query.throwErrors === undefined ? true : query.throwErrors;
     this.actions = actionCreatorsFor(this);
     this.pagedFetchSuccess = this.actions.fetchSuccess;
     this.reducer = reducer.bind(this);

--- a/RESTResource/actionCreatorsFor.js
+++ b/RESTResource/actionCreatorsFor.js
@@ -3,6 +3,7 @@ export default function actionCreatorsFor(resource) {
     resource: resource.name,
     module: resource.module,
     dataKey: resource.dataKey,
+    throwErrors: resource.throwErrors,
   };
   const passPayload = name => data => ({
     type: `@@stripes-connect/${name}`,

--- a/doc/api.md
+++ b/doc/api.md
@@ -321,6 +321,22 @@ only if the names path-component, query parameter or local resource
 _does_ exist: `%{name:+val}` yields either the constant `val` or an
 empty string, according as `%{name}` is or is not defined.
 
+#### Error handling
+
+Normally, errors will be caught and processed by Stripes Connect.
+Currently, errors are being reported in an `alert()` via Stripes
+Core to ensure that they are noticed during development. However,
+this means that `catch` calls like
+`mutator.values.DELETE(...).then(...).catch(...)` will never be
+executed.
+
+If you wish to be responsible for and handle your own errors
+for a particular resource, add a `throwErrors: false` property
+to that resource's object in the manifest.
+
+Note that the errors will still be listed in `failedMutations`,
+this just turns off the current error handling in Stripes Core.
+
 #### Example path
 
 Putting these facilities together, the following `path` could be

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-connect",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Declarative REST data access for React components",
   "repository": "folio-org/stripes-connect",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-connect",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Declarative REST data access for React components",
   "repository": "folio-org/stripes-connect",
   "publishConfig": {


### PR DESCRIPTION
Allow a `LocalResource` to be initialized with a falsey scalar value such as `0` or an empty string. Previously, falsey init values would cause the resource to be initialized with an empty object instead. 

Refs [STCON-65](https://issues.folio.org/browse/STCON-65)