### PR TITLE
Allow LocalResource init with falsey scalar values. Refs STCON-65

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * `verbOptions` returns null if any of the templated values are incomplete. Fixes STCON-58.
 * Failed fetches on a resource clear existing data from that resource. Fixes STCON-64. Available from v3.1.1.
 * Added ability to specify `throwErrors` boolean in resource manifests. Setting to `false` turns off global error reporting for that resource. Available from v3.1.2.
+* Allow LocalResource to be initalized with a non-object falsey value. Refs STCON-65. Available from v3.1.3.
 
 ## [3.1.0](https://github.com/folio-org/stripes-connect/tree/v3.1.0) (2018-01-09)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v3.0.0...v3.1.0)

--- a/LocalResource.js
+++ b/LocalResource.js
@@ -36,7 +36,7 @@ export default class LocalResource {
 
   stateKey = () => `${this.dataKey ? `${this.dataKey}#` : ''}${_.snakeCase(this.module)}_${this.name}`;
 
-  reducer = (state = this.query.initialValue ? this.query.initialValue : {}, action) => {
+  reducer = (state = this.query.initialValue !== undefined ? this.query.initialValue : {}, action) => {
     if (action.meta !== undefined &&
         action.meta.module === this.module &&
         action.meta.resource === this.name &&

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-connect",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Declarative REST data access for React components",
   "repository": "folio-org/stripes-connect",
   "publishConfig": {


### PR DESCRIPTION
Previously, initializing a `LocalResource` with a falsey value would cause that value to be converted to an empty object. This change preserves the original type of the initial value. 

Refs [STCON-65](https://issues.folio.org/browse/STCON-65)