### PR TITLE
augment details for `connect`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Failed fetches on a resource clear existing data from that resource. Fixes STCON-64. Available from v3.1.1.
 * Added ability to specify `throwErrors` boolean in resource manifests. Setting to `false` turns off global error reporting for that resource. Available from v3.1.2.
 * Allow LocalResource to be initalized with a non-object falsey value. Refs STCON-65. Available from v3.1.3.
+* Updating `connect` documentation.
 
 ## [3.1.0](https://github.com/folio-org/stripes-connect/tree/v3.1.0) (2018-01-09)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v3.0.0...v3.1.0)

--- a/doc/api.md
+++ b/doc/api.md
@@ -460,7 +460,7 @@ value for each connected instance:
         render() {
           return (
             <div>
-              {this.connectedLoans.map(comp => <comp stripes={this.props.stripes} />}
+              {this.connectedLoans.map(comp => <comp stripes={this.props.stripes} />)}
             </div>
           );
         }

--- a/doc/api.md
+++ b/doc/api.md
@@ -447,9 +447,9 @@ passes the module name to connect:
         }
 
 Because the resource object is global to the module, if the same component
-will be used repeatedly to retrieve different value for each item on a list,
+will be used repeatedly to retrieve a different value for each item on a list,
 e.g. when connecting `<LoanDetails>` repeatedly to retrieve the details of
-multiple loan, it is necessary to provide the `dataKey` option with a unique
+multiple loans, it is necessary to provide the `dataKey` option with a unique
 value for each connected instance:
 
         constructor(props) {
@@ -460,7 +460,7 @@ value for each connected instance:
         render() {
           return (
             <div>
-              {this.connectedLoans.map(comp =><comp stripes={this.props.stripes} />}
+              {this.connectedLoans.map(comp => <comp stripes={this.props.stripes} />}
             </div>
           );
         }

--- a/doc/api.md
+++ b/doc/api.md
@@ -437,6 +437,33 @@ use
 the Stripes module that contains the connect component. We hope to
 remove this requirement in future.)
 
+When a parent component is connecting one of its children, it may use the
+curried form of `connect`, provided on the `stripes` prop, which implicitly
+passes the module name to connect:
+
+        constructor(props) {
+          super();
+          this.connectedWidget = props.stripes.connect(Widget);
+        }
+
+Because the resource object is global to the module, if the same component
+will be used repeatedly to retrieve different value for each item on a list,
+e.g. when connecting `<LoanDetails>` repeatedly to retrieve the details of
+multiple loan, it is necessary to provide the `dataKey` option with a unique
+value for each connected instance:
+
+        constructor(props) {
+          super();
+          this.connectedLoans = this.props.IDs.map(id => props.stripes.connect(LoanDetails, { dataKey: id }));
+        }
+
+        render() {
+          return (
+            <div>
+              {this.connectedLoans.map(comp =><comp stripes={this.props.stripes} />}
+            </div>
+          );
+        }
 
 ## Using the connected component
 


### PR DESCRIPTION
Details about how to use `props.stripes.connect` and how/why to use the
`dataKey` option were completely absent.

Fixes [STCON-61](https://issues.folio.org/browse/STCON-61)