### PR TITLE
STCOR-208: use redux args instead of context

### DIFF
--- a/connect.js
+++ b/connect.js
@@ -45,14 +45,20 @@ const wrap = (Wrapped, module, epics, logger, addReducer, store, options = {}) =
       dataKey: PropTypes.string,
     };
 
-    constructor() {
+    constructor(props, context) {
       super();
+      this.context = context;
       this.logger = logger;
       Wrapper.logger = logger;
       logger.log('connect-lifecycle', `constructed <${Wrapped.name}>, resources =`, resources);
 
       if (!(addReducer)) {
-        throw new Error('No addReducer function available. You need to call connectFor() first to initialize connect() with redux');
+        // check if available via legacy context API
+        addReducer = context.addReducer; // eslint-disable-line no-param-reassign
+        store = context.store; // eslint-disable-line no-param-reassign
+        if (!(addReducer)) {
+          throw new Error('No addReducer function available');
+        }
       }
       resources.forEach((resource) => {
         // Hopefully paging can all be absorbed into the resource in some future
@@ -132,6 +138,11 @@ const wrap = (Wrapped, module, epics, logger, addReducer, store, options = {}) =
     }
   }
 
+  Wrapper.contextTypes = {
+    addReducer: PropTypes.func,
+    store: PropTypes.object,
+  };
+
   Wrapper.mapState = (state) => {
     logger.log('connect-lifecycle', `mapState for <${Wrapped.name}>, resources =`, resources);
 
@@ -186,6 +197,6 @@ export const connect = (Component, module, epics, loggerArg, addReducer, store, 
   return Connected;
 };
 
-export const connectFor = (module, epics, logger, addReducer, store) => (Component, options) => connect(Component, module, epics, logger, addReducer, store, options);
+export const connectFor = (module, epics, logger, addReducer = null, store = null) => (Component, options) => connect(Component, module, epics, logger, addReducer, store, options);
 
 export default connect;

--- a/connect.js
+++ b/connect.js
@@ -15,7 +15,7 @@ const types = {
   rest: RESTResource,
 };
 
-const wrap = (Wrapped, module, epics, logger, options = {}) => {
+const wrap = (Wrapped, module, epics, logger, addReducer, store, options = {}) => {
   const resources = [];
   const dataKey = options.dataKey;
 
@@ -45,18 +45,14 @@ const wrap = (Wrapped, module, epics, logger, options = {}) => {
       dataKey: PropTypes.string,
     };
 
-    constructor(props, context) {
+    constructor() {
       super();
-      this.context = context;
       this.logger = logger;
       Wrapper.logger = logger;
       logger.log('connect-lifecycle', `constructed <${Wrapped.name}>, resources =`, resources);
-    }
 
-    componentWillMount() {
-      // this.logger.log('connect', `in componentWillMount for ${Wrapped.name}`);
-      if (!(this.context.addReducer)) {
-        throw new Error('No addReducer function available in component context');
+      if (!(addReducer)) {
+        throw new Error('No addReducer function available');
       }
       resources.forEach((resource) => {
         // Hopefully paging can all be absorbed into the resource in some future
@@ -64,8 +60,7 @@ const wrap = (Wrapped, module, epics, logger, options = {}) => {
         // few million less times)
         if (resource.pagingReducer) {
           const pagingKey = `${resource.stateKey()}_paging`;
-          this.context.addReducer(pagingKey, resource.pagingReducer);
-          const store = this.context.store;
+          addReducer(pagingKey, resource.pagingReducer);
           const onPageSuccess = (paging) => {
             const records = paging.reduce((acc, val) => acc.concat(val.records), []);
             // store.dispatch(resource.pagedFetchSuccess(records));
@@ -83,7 +78,7 @@ const wrap = (Wrapped, module, epics, logger, options = {}) => {
           };
           store.subscribe(pagingListener);
         }
-        this.context.addReducer(resource.stateKey(), resource.reducer);
+        addReducer(resource.stateKey(), resource.reducer);
       });
     }
 
@@ -137,11 +132,6 @@ const wrap = (Wrapped, module, epics, logger, options = {}) => {
     }
   }
 
-  Wrapper.contextTypes = {
-    addReducer: PropTypes.func,
-    store: PropTypes.object,
-  };
-
   Wrapper.mapState = (state) => {
     logger.log('connect-lifecycle', `mapState for <${Wrapped.name}>, resources =`, resources);
 
@@ -184,18 +174,18 @@ defaultLogger.log = (cat, ...args) => {
   console.log(`stripes-connect (${cat})`, ...args);
 };
 
-export const connect = (Component, module, epics, loggerArg, options) => {
+export const connect = (Component, module, epics, loggerArg, addReducer, store, options) => {
   const logger = loggerArg || defaultLogger;
   if (typeof Component.manifest === 'undefined') {
     logger.log('connect-no', `not connecting <${Component.name}> for '${module}': no manifest`);
     return Component;
   }
   logger.log('connect', `connecting <${Component.name}> for '${module}'`);
-  const Wrapper = wrap(Component, module, epics, logger, options);
+  const Wrapper = wrap(Component, module, epics, logger, addReducer, store, options);
   const Connected = reduxConnect(Wrapper.mapState, Wrapper.mapDispatch, Wrapper.mergeProps)(Wrapper);
   return Connected;
 };
 
-export const connectFor = (module, epics, logger) => (Component, options) => connect(Component, module, epics, logger, options);
+export const connectFor = (module, epics, logger, addReducer, store) => (Component, options) => connect(Component, module, epics, logger, addReducer, store, options);
 
 export default connect;

--- a/connect.js
+++ b/connect.js
@@ -52,7 +52,7 @@ const wrap = (Wrapped, module, epics, logger, addReducer, store, options = {}) =
       logger.log('connect-lifecycle', `constructed <${Wrapped.name}>, resources =`, resources);
 
       if (!(addReducer)) {
-        throw new Error('No addReducer function available');
+        throw new Error('No addReducer function available. You need to call connectFor() first to initialize connect() with redux');
       }
       resources.forEach((resource) => {
         // Hopefully paging can all be absorbed into the resource in some future

--- a/connect.js
+++ b/connect.js
@@ -15,7 +15,7 @@ const types = {
   rest: RESTResource,
 };
 
-const wrap = (Wrapped, module, epics, logger, addReducer, store, options = {}) => {
+const wrap = (Wrapped, module, epics, logger, options = {}, addReducer, store) => {
   const resources = [];
   const dataKey = options.dataKey;
 
@@ -185,18 +185,18 @@ defaultLogger.log = (cat, ...args) => {
   console.log(`stripes-connect (${cat})`, ...args);
 };
 
-export const connect = (Component, module, epics, loggerArg, addReducer, store, options) => {
+export const connect = (Component, module, epics, loggerArg, options, addReducer, store) => {
   const logger = loggerArg || defaultLogger;
   if (typeof Component.manifest === 'undefined') {
     logger.log('connect-no', `not connecting <${Component.name}> for '${module}': no manifest`);
     return Component;
   }
   logger.log('connect', `connecting <${Component.name}> for '${module}'`);
-  const Wrapper = wrap(Component, module, epics, logger, addReducer, store, options);
+  const Wrapper = wrap(Component, module, epics, logger, options, addReducer, store);
   const Connected = reduxConnect(Wrapper.mapState, Wrapper.mapDispatch, Wrapper.mergeProps)(Wrapper);
   return Connected;
 };
 
-export const connectFor = (module, epics, logger, addReducer = null, store = null) => (Component, options) => connect(Component, module, epics, logger, addReducer, store, options);
+export const connectFor = (module, epics, logger, addReducer = null, store = null) => (Component, options) => connect(Component, module, epics, logger, options, addReducer, store);
 
 export default connect;


### PR DESCRIPTION
Remove legacy context API. Pass the two redux-related things, `addReducer` and `store`, as arguments.

Accompanies https://github.com/folio-org/stripes-core/pull/358