### PR TITLE
Add a new permissionsRequired option to a manifest's object. Fixes STCON-68

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Added ability to specify `throwErrors` boolean in resource manifests. Setting to `false` turns off global error reporting for that resource. Available from v3.1.2.
 * Allow LocalResource to be initalized with a non-object falsey value. Refs STCON-65. Available from v3.1.3.
 * Updating `connect` documentation.
+* Add a new `permissionsRequired` prop to a manifest's object. Fixes STCON-68. Available from v3.1.5.
 
 ## [3.1.0](https://github.com/folio-org/stripes-connect/tree/v3.1.0) (2018-01-09)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v3.0.0...v3.1.0)

--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -482,15 +482,15 @@ export default class RESTResource {
       const state = getState();
       const options = this.verbOptions('GET', state, props);
 
-      if (options.permissionsRequired && !this.hasPerm(state, options.permissionsRequired)) {
-        dispatch(this.actions.fetchAbort({ message: 'cannot satisfy request: missing permissions' }));
-        return null;
-      }
-
       if (options === null) {
         dispatch(this.actions.fetchAbort({ message: 'cannot satisfy request: missing query?' }));
         this.lastUrl = null;
         return null; // needs dynamic parts that aren't available
+      }
+
+      if (options.permissionsRequired && !this.hasPerm(state, options.permissionsRequired)) {
+        dispatch(this.actions.fetchAbort({ message: 'cannot satisfy request: missing permissions' }));
+        return null;
       }
 
       const url = urlFromOptions(options);

--- a/connect.js
+++ b/connect.js
@@ -97,7 +97,8 @@ const wrap = (Wrapped, module, epics, logger, options = {}) => {
       });
     }
 
-    componentWillReceiveProps(nextProps) {
+    // eslint-disable-next-line camelcase
+    UNSAFE_componentWillReceiveProps(nextProps) {
       // this.logger.log('connect', `in componentWillReceiveProps for ${Wrapped.name}: nextProps.location=`, nextProps.location, 'this.props.location=', this.props.location);
       if (this.componentShouldRefreshRemote(nextProps)) {
         this.props.refreshRemote({ ...nextProps });

--- a/connect.js
+++ b/connect.js
@@ -97,8 +97,7 @@ const wrap = (Wrapped, module, epics, logger, options = {}) => {
       });
     }
 
-    // eslint-disable-next-line camelcase
-    UNSAFE_componentWillReceiveProps(nextProps) {
+    componentWillReceiveProps(nextProps) {
       // this.logger.log('connect', `in componentWillReceiveProps for ${Wrapped.name}: nextProps.location=`, nextProps.location, 'this.props.location=', this.props.location);
       if (this.componentShouldRefreshRemote(nextProps)) {
         this.props.refreshRemote({ ...nextProps });

--- a/doc/api.md
+++ b/doc/api.md
@@ -163,6 +163,9 @@ via limitParam/offsetParam.
   resource, which allows it to be used in code that expects to receive a
   promise. Default: `false`.
 
+* `permissionsRequired`: A string (or an array of strings) indicating the list
+  of permissions required for the given resource to be fetched.
+
 In addition to these principal pieces of configuration, which apply to
 all operations on the resource, these values can be overridden for
 specific HTTP operations: the entries `GET`, `POST`, `PUT`, `DELETE`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-connect",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "description": "Declarative REST data access for React components",
   "repository": "folio-org/stripes-connect",
   "publishConfig": {

--- a/test/integration.js
+++ b/test/integration.js
@@ -330,7 +330,6 @@ describe('connect()', () => {
       const res = inst.find(CompWithPerms).instance().props.resources.resourceWithPerms;
       res.isPending.should.equal(false);
       res.hasLoaded.should.equal(false);
-      console.log(store.getState());
       fetchMock.restore();
       done();
     }, 10);


### PR DESCRIPTION
https://issues.folio.org/browse/STCON-68

This PR introduces a new `permissionsRequired` prop to a manifest's object. The initial discussion can be found here:

https://github.com/folio-org/ui-users/commit/8558adef98e1d135314eaf9831d2decc459021b0#diff-6c4a67641cbff8412246381fb1851b26
