### PR TITLE
Fixed bug with function-defined params

### DIFF
--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -480,7 +480,6 @@ export default class RESTResource {
 
     return (dispatch, getState) => {
       const state = getState();
-      console.log('params', _.get(props, ['match', 'params']));
       const options = this.verbOptions('GET', state, props);
 
       if (options === null) {

--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -259,7 +259,7 @@ export default class RESTResource {
         }
       } else if (typeof options.params === 'function') {
         const parsedQuery = queryString.parse(_.get(props, ['location', 'search']));
-        options.params = options.params(parsedQuery, _.get(props, ['match', 'params']), mockProps(state, module, props.dataKey, this.logger).data, this.logger);
+        options.params = options.params(parsedQuery, _.get(props, ['match', 'params']), mockProps(state, this.module, props.dataKey, this.logger).resources, this.logger);
       }
 
       // recordsRequired
@@ -480,6 +480,7 @@ export default class RESTResource {
 
     return (dispatch, getState) => {
       const state = getState();
+      console.log('params', _.get(props, ['match', 'params']));
       const options = this.verbOptions('GET', state, props);
 
       if (options === null) {


### PR DESCRIPTION
When a resource defined its `params` using a function, the `resources` object passed into the function as an argument wasn't correct. This was due to:

1. The incorrect module name being passed into `mockProps`
2. The incorrect prop being taken from the return value of `mockProps` and passed into the `params` function.