### PR TITLE
Move stripes-core to peerDependencies. Part of STRIPES-557

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 3.3.0 (IN PROGRESS)
 
+* move stripes-core to `peerDependencies`. Part of STRIPES-557.
+
 ## [3.2.0](https://github.com/folio-org/stripes-connect/tree/v3.2.0) (2018-09-05)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v3.1.0...v3.2.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.3.0 (IN PROGRESS)
 
-* move stripes-core to `peerDependencies`. Part of STRIPES-557.
+* Move stripes-core to `peerDependencies`. Part of STRIPES-557.
 
 ## [3.2.0](https://github.com/folio-org/stripes-connect/tree/v3.2.0) (2018-09-05)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v3.1.0...v3.2.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-connect",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Declarative REST data access for React components",
   "repository": "folio-org/stripes-connect",
   "publishConfig": {
@@ -18,6 +18,7 @@
     "lint": "eslint *.js RESTResource/*.js"
   },
   "devDependencies": {
+    "@folio/stripes-core": "^2.13.0",
     "babel-core": "^6.17.0",
     "babel-eslint": "^8.0.0",
     "babel-preset-env": "^1.6.0",
@@ -40,7 +41,6 @@
     "webpack": "^3.6.0"
   },
   "dependencies": {
-    "@folio/stripes-core": "^2.10.4",
     "isomorphic-fetch": "^2.2.1",
     "lodash": "^4.17.2",
     "prop-types": "^15.5.10",
@@ -51,6 +51,7 @@
     "uuid": "^3.0.1"
   },
   "peerDependencies": {
+    "@folio/stripes-core": "^2.13.0",
     "react": "*",
     "react-dom": "*"
   }


### PR DESCRIPTION
Also adding it to devDependencies to make sure we can still run tests. 