### PR TITLE
make stripes-core a peerDependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change history for stripes-connect
 
-## 3.2.0 (IN PROGRESS)
+## 3.2.1 (IN PROGRESS)
+
+* stripes-core should be a peerDependency. Refs STRIPES-557.
+
+## [3.2.0](https://github.com/folio-org/stripes-connect/tree/v3.2.0) (2018-09-05)
+[Full Changelog](https://github.com/folio-org/stripes-connect/compare/v3.1.0...v3.2.0)
 
 * `verbOptions` returns null if any of the templated values are incomplete. Fixes STCON-58.
 * Failed fetches on a resource clear existing data from that resource. Fixes STCON-64. Available from v3.1.1.

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "enzyme-adapter-react-16": "^1.1.1",
     "eslint": "^4.8.0",
     "@folio/eslint-config-stripes": "^1.1.0",
+    "@folio/stripes-core": "^2.10.4",
     "fetch-mock": "5.11.2",
     "jsdom": "^11.0.0",
     "jsdom-global": "^3.0.2",
@@ -40,7 +41,6 @@
     "webpack": "^3.6.0"
   },
   "dependencies": {
-    "@folio/stripes-core": "^2.10.4",
     "isomorphic-fetch": "^2.2.1",
     "lodash": "^4.17.2",
     "prop-types": "^15.5.10",
@@ -51,6 +51,7 @@
     "uuid": "^3.0.1"
   },
   "peerDependencies": {
+    "@folio/stripes-core": "^2.10.4",
     "react": "*",
     "react-dom": "*"
   }


### PR DESCRIPTION
stripes-core must be a peerDependency so it is included once per bundle.
Listing it as a regular dependency means it may be nested, rather than
hoisted, which can lead to multiple versions, but separate versions will
have separate instances of context, resulting in context-consumers that
can't see the context offered by the context-providers they are trying
to subscribe too.

Refs STRIPES-557