### PR TITLE
Add shouldRefresh function to a manifest's object. Part of STCON-71

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.2.1 (IN PROGRESS)
 
 * stripes-core should be a peerDependency. Refs STRIPES-557.
+* Add `shouldRefresh` function to a manifest's object. Part of STCON-71.
 
 ## [3.2.0](https://github.com/folio-org/stripes-connect/tree/v3.2.0) (2018-09-05)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v3.1.0...v3.2.0)

--- a/doc/api.md
+++ b/doc/api.md
@@ -166,6 +166,9 @@ via limitParam/offsetParam.
 * `permissionsRequired`: A string (or an array of strings) indicating the list
   of permissions required for the given resource to be fetched.
 
+* `shouldRefresh`: An optional function which can be used to indicate if the
+given resource should be refreshed when another resource is mutated.
+
 In addition to these principal pieces of configuration, which apply to
 all operations on the resource, these values can be overridden for
 specific HTTP operations: the entries `GET`, `POST`, `PUT`, `DELETE`

--- a/epics/refresh.js
+++ b/epics/refresh.js
@@ -4,18 +4,20 @@ export function refreshEpic(resource) {
   return (action$) => action$
     .ofType('REFRESH')
     .filter(action => {
-      const { name, path } = action.meta;
+      const { path } = action.meta;
       const options = resource.optionsTemplate;
-      const resPath = options.path || '';
+      const resPath = options.path || (options.GET || {}).path || '';
 
       if (!resource.isVisible()) return false;
 
+      let refresh = resPath.startsWith(path);
+
       if (options.shouldRefresh) {
-        return options.shouldRefresh(resource, action);
+        refresh ||= options.shouldRefresh(resource, action);
       }
-      else {
-        return resPath.startsWith(path);
-      }
+
+      return refresh;
+
     })
     .debounceTime(100)
     .map(action => {

--- a/epics/refresh.js
+++ b/epics/refresh.js
@@ -5,8 +5,17 @@ export function refreshEpic(resource) {
     .ofType('REFRESH')
     .filter(action => {
       const { name, path } = action.meta;
-      const resPath = resource.optionsTemplate.path || '';
-      return resource.isVisible() && resPath.startsWith(path);
+      const options = resource.optionsTemplate;
+      const resPath = options.path || '';
+
+      if (!resource.isVisible()) return false;
+
+      if (options.shouldRefresh) {
+        return options.shouldRefresh(resource, action);
+      }
+      else {
+        return resPath.startsWith(path);
+      }
     })
     .debounceTime(100)
     .map(action => {

--- a/epics/refresh.js
+++ b/epics/refresh.js
@@ -13,7 +13,7 @@ export function refreshEpic(resource) {
       let refresh = resPath.startsWith(path);
 
       if (options.shouldRefresh) {
-        refresh ||= options.shouldRefresh(resource, action);
+        refresh = refresh || options.shouldRefresh(resource, action);
       }
 
       return refresh;

--- a/epics/refresh.js
+++ b/epics/refresh.js
@@ -13,7 +13,7 @@ export function refreshEpic(resource) {
       let refresh = resPath.startsWith(path);
 
       if (options.shouldRefresh) {
-        refresh = refresh || options.shouldRefresh(resource, action);
+        refresh = options.shouldRefresh(resource, action, refresh);
       }
 
       return refresh;


### PR DESCRIPTION
This PR introduces a new optional function called `shouldRefresh` to a manifest's object. If the function is present it will be used by the refresh epic to indicate if the give resource should be refreshed or not. 

The functionality is backwards compatible meaning that if the `shouldRefresh` is not present the path matching will be used instead. 