### PR TITLE
Revert stripes-core v3.0.0 dependency change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change history for stripes-connect
 
+## [3.4.1](https://github.com/folio-org/stripes-connect/tree/v3.4.0) (2019-01-16)
+[Full Changelog](https://github.com/folio-org/stripes-connect/compare/v3.4.0...v3.4.1)
+
+* Revert `stripes-core` `v3.0.0` dependency change
+
 ## [3.4.0](https://github.com/folio-org/stripes-connect/tree/v3.4.0) (2019-01-15)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v3.3.1...v3.4.0)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-connect",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "Declarative REST data access for React components",
   "repository": "folio-org/stripes-connect",
   "publishConfig": {
@@ -34,7 +34,7 @@
     "redux-thunk": "^2.1.0"
   },
   "dependencies": {
-    "@folio/stripes-core": "^2.15.0 || ^3.0.0",
+    "@folio/stripes-core": "^2.15.0",
     "isomorphic-fetch": "^2.2.1",
     "lodash": "^4.17.2",
     "prop-types": "^15.5.10",


### PR DESCRIPTION
Part of resolution for https://issues.folio.org/browse/FOLIO-1707

`stripes-connect` and `stripes-form` will need major version bumps to prevent newer versions of `stripes-*` dependencies from leaking in.