### PR TITLE
make stripes-core dep more strict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-connect
 
+## 4.0.1 (IN PROGRESS)
+
+* Make the stripes-core dependency more strict with ~ instead of ^.
+
 ## [4.0.0](https://github.com/folio-org/stripes-connect/tree/v4.0.0) (2019-01-16)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v3.4.1...v4.0.0)
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "redux-thunk": "^2.1.0"
   },
   "dependencies": {
-    "@folio/stripes-core": "^3.0.0",
+    "@folio/stripes-core": "~3.0.4",
     "isomorphic-fetch": "^2.2.1",
     "lodash": "^4.17.2",
     "prop-types": "^15.5.10",


### PR DESCRIPTION
Caret dependencies are too loose in the context of releasing a platform
and allow new minor release to "leak" up into a platform where the
differing versions can cause duplication errors.

Refs [STRIPES-608](https://issues.folio.org/browse/STRIPES-608)