### PR TITLE
sync master version with releases from branches

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-connect",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Declarative REST data access for React components",
   "repository": "folio-org/stripes-connect",
   "publishConfig": {


### PR DESCRIPTION
The version on master must always be >= that of the version on a branch.
Otherwise, repos that update to a patch release (from a branch) may be
prevent from using the tip-of-master version provided in their
workspace.