### PR TITLE
STCON-76  Option#2: core circular dependency withConnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change history for stripes-connect
 
+## [5.0.0](https://github.com/folio-org/stripes-connect/tree/v5.0.0) (2019-03-14)
+[Full Changelog](https://github.com/folio-org/stripes-connect/compare/v4.1.0...v5.0.0)
+
+* Provide ConnectContext internally to eliminate dependency on stripes-core/circular dependency. Fixes STCON-76.
+
 ## [4.1.0](https://github.com/folio-org/stripes-connect/tree/v4.1.0) (2019-03-14)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v4.0.1...v4.1.0)
 

--- a/ConnectContext.js
+++ b/ConnectContext.js
@@ -1,0 +1,23 @@
+import React from 'react';
+
+const ConnectContext = React.createContext();
+
+function getDisplayName(WrappedComponent) {
+  return WrappedComponent.displayName || WrappedComponent.name || 'Component';
+}
+
+export function withConnect(WrappedComponent) {
+  class WithConnect extends React.Component {
+    render() {
+      return (
+        <ConnectContext.Consumer>
+          {root => <WrappedComponent {...this.props} root={root} /> }
+        </ConnectContext.Consumer>
+      );
+    }
+  }
+  WithConnect.displayName = `WithConnect(${getDisplayName(WrappedComponent)})`;
+  return WithConnect;
+}
+
+export default ConnectContext;

--- a/connect.js
+++ b/connect.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 import { connect as reduxConnect } from 'react-redux';
-import { withRoot } from '@folio/stripes-core/src/components/Root/RootContext';
+import { withConnect } from './ConnectContext';
 
 import OkapiResource from './OkapiResource';
 import RESTResource from './RESTResource';
@@ -195,10 +195,12 @@ export const connect = (Component, module, epics, loggerArg, options) => {
   }
   logger.log('connect', `connecting <${Component.name}> for '${module}'`);
   const Wrapper = wrap(Component, module, epics, logger, options);
-  const Connected = reduxConnect(Wrapper.mapState, Wrapper.mapDispatch, Wrapper.mergeProps)(withRoot(Wrapper));
+  const Connected = reduxConnect(Wrapper.mapState, Wrapper.mapDispatch, Wrapper.mergeProps)(withConnect(Wrapper));
   return Connected;
 };
 
 export const connectFor = (module, epics, logger) => (Component, options) => connect(Component, module, epics, logger, options);
+
+export { default as ConnectContext, withConnect } from './ConnectContext';
 
 export default connect;

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "@folio/eslint-config-stripes": "^3.2.1",
     "babel-eslint": "^10.0.1",
     "babel-register": "^6.26.0",
+    "babel-preset-env": "^1.6.0",
+    "babel-preset-react": "^6.16.0",
+    "babel-preset-stage-2": "^6.16.0",
     "chai": "^4.0.2",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
@@ -34,7 +37,6 @@
     "redux-thunk": "^2.1.0"
   },
   "dependencies": {
-    "@folio/stripes-core": "~3.1.0",
     "isomorphic-fetch": "^2.2.1",
     "lodash": "^4.17.2",
     "prop-types": "^15.5.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-connect",
-  "version": "4.1.0",
+  "version": "5.0.0",
   "description": "Declarative REST data access for React components",
   "repository": "folio-org/stripes-connect",
   "publishConfig": {

--- a/test/integration.js
+++ b/test/integration.js
@@ -10,7 +10,7 @@ import { createStore, applyMiddleware, combineReducers } from 'redux';
 import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
 import fetchMock from 'fetch-mock';
-import { RootContext } from '@folio/stripes-core/src/components/Root/RootContext';
+import ConnectContext from '../ConnectContext';
 
 import { connect } from '../connect';
 
@@ -39,9 +39,9 @@ class Root extends Component {
     const { component:ToTest } = this.props;
     return (
       <Provider store={this.props.store}>
-        <RootContext.Provider value={{ addReducer: this.addReducer, addEpic: this.addEpic, store: this.props.store }}>
+        <ConnectContext.Provider value={{ addReducer: this.addReducer, addEpic: this.addEpic, store: this.props.store }}>
           <ToTest {...this.props} />
-        </RootContext.Provider>
+        </ConnectContext.Provider>
       </Provider>
     );
   }


### PR DESCRIPTION
Hot on the heels of  #79 , This PR involves bringing the 'rootContext' over to the `stripes-connect` side of the line.
## Pros
- No breaking changes (if merged in close proximity to the stripes-core PR)
- Local HOC's/Contexts get needed for tests for either case.

## Cons
- There can now be only one `stripes-connect` in the platform, due to the use of new Context API.