### PR TITLE
Turned off sideEffects to enable tree-shaking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for stripes-connect
 
+## 5.0.1 (IN-PROGRESS)
+* Turned off sideEffects to enable tree-shaking for production builds. Refs STRIPES-564 and STRIPES-581.
+
 ## [5.0.0](https://github.com/folio-org/stripes-connect/tree/v5.0.0) (2019-03-14)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v4.1.0...v5.0.0)
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "5.0.0",
   "description": "Declarative REST data access for React components",
   "repository": "folio-org/stripes-connect",
+  "sideEffects": ["*.css"],
   "publishConfig": {
     "registry": "https://repository.folio.org/repository/npm-folio/"
   },


### PR DESCRIPTION
- Tested with sample "Hello World" UI app. No difference in bundle size but this will shake future unused code blocks.