### PR TITLE
Support substitution for clientGeneratePk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-connect
 
+## 5.2.0 (IN PROGRESS)
+
+* Run substitution on the `clientGeneratePk` manifest option, allowing it to be set from (for example) a prop.
+
 ## [5.1.0](https://github.com/folio-org/stripes-connect/tree/v5.1.0) (2019-04-25)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v5.0.0...v5.1.0)
 

--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -186,8 +186,10 @@ export function substitute(original, props, state, module, logger, dataKey) {
     result = original(parsedQuery, _.get(props, ['match', 'params']), localProps, logger);
   } else if (typeof original === 'string') {
     result = compilePathTemplate(original, parsedQuery, props, localProps);
+  } else if (typeof original === 'boolean') {
+    result = original;
   } else {
-    throw new Error('Invalid type passed to RESTResource.substitute()');
+    throw new Error(`Invalid type passed to RESTResource.substitute(): ${typeof original} (${original})`);
   }
 
   logger.log('substitute', `substitute(${
@@ -276,6 +278,10 @@ export default class RESTResource {
       // records
       if (options.records) {
         options.records = substitute(options.records, props, state, this.module, this.logger, this.dataKey);
+      }
+
+      if (options.clientGeneratePk) {
+        options.clientGeneratePk = substitute(options.clientGeneratePk, props, state, this.module, this.logger, this.dataKey);
       }
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-connect",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Declarative REST data access for React components",
   "repository": "folio-org/stripes-connect",
   "sideEffects": ["*.css"],


### PR DESCRIPTION
It's now possible for the `clientGeneratePk` manifest option to take any of the forms that `path` and other options can take. So for example, your manifest can specify `clientGeneratePk: '!{foo}'` to use the value of the `foo` prop. (This is in fact exactly what `<ControlledVocab>` does to allow its caller to pass in a prop indicating whether ot not to have the client generate an ID.

As well as adding the line that runs substitute on `clientGeneratePk`, I had to tweak `substitute` so it passes through boolean values (as the default value is `true`). While I was there, I made the diagnostic for an unsupported type a bit more verbose, as that would have helped me to track down what was otherwise a slightly obscure error thrown by the test suite.