### PR TITLE
Improve mutation and refresh epics. Part of STCON-80

### DIFF
--- a/RESTResource/actionCreatorsFor.js
+++ b/RESTResource/actionCreatorsFor.js
@@ -18,15 +18,15 @@ export default function actionCreatorsFor(resource) {
   return {
     createStart: passPayload('CREATE_START'),
 
-    createSuccess: passPayload('CREATE_SUCCESS'),
+    createSuccess: passMetaPayload('CREATE_SUCCESS'),
 
     updateStart: passPayload('UPDATE_START'),
 
-    updateSuccess: passPayload('UPDATE_SUCCESS'),
+    updateSuccess: passMetaPayload('UPDATE_SUCCESS'),
 
     deleteStart: passPayload('DELETE_START'),
 
-    deleteSuccess: passPayload('DELETE_SUCCESS'),
+    deleteSuccess: passMetaPayload('DELETE_SUCCESS'),
 
     mutationError: (err, mutator) => ({
       type: '@@stripes-connect/MUTATION_ERROR',

--- a/epics/mutationEpics.js
+++ b/epics/mutationEpics.js
@@ -7,13 +7,13 @@ const actionNames = [
 // returns list of epics which execute
 // after mutation happens on a given resource
 export default function mutationEpics(resource) {
-  const options = resource.optionsTemplate;
-
   return actionNames.map(actionName => (action$) => action$
     .ofType(`@@stripes-connect/${actionName}`)
     .filter(action => action.meta.resource === resource.name)
     .map(action => {
-      const path = options.path && options.path.replace(/[\/].*$/g, '');  // eslint-disable-line no-useless-escape
+      let { meta: { path } } = action;
+      path = path && path.replace(/[\/].*$/g, '');  // eslint-disable-line no-useless-escape
+
       const name = resource.name;
       const meta = Object.assign({}, action.meta, { path, name });
       return { ...action, meta, type: 'REFRESH' };

--- a/epics/refreshEpic.js
+++ b/epics/refreshEpic.js
@@ -1,5 +1,3 @@
-import isString from 'lodash/isString';
-
 // returns epic which executes after a refresh action
 // and syncs/refreshes given resource
 export default function refreshEpic(resource) {
@@ -12,7 +10,7 @@ export default function refreshEpic(resource) {
 
       if (!resource.isVisible()) return false;
 
-      let refresh = isString(resPath) && resPath.startsWith(path);
+      let refresh = (typeof resPath === 'string') && resPath.startsWith(path);
 
       if (options.shouldRefresh) {
         refresh = options.shouldRefresh(resource, action, refresh);

--- a/epics/refreshEpic.js
+++ b/epics/refreshEpic.js
@@ -1,3 +1,5 @@
+import isString from 'lodash/isString';
+
 // returns epic which executes after a refresh action
 // and syncs/refreshes given resource
 export default function refreshEpic(resource) {
@@ -10,7 +12,7 @@ export default function refreshEpic(resource) {
 
       if (!resource.isVisible()) return false;
 
-      let refresh = resPath.startsWith(path);
+      let refresh = isString(resPath) && resPath.startsWith(path);
 
       if (options.shouldRefresh) {
         refresh = options.shouldRefresh(resource, action, refresh);

--- a/package.json
+++ b/package.json
@@ -1,9 +1,11 @@
 {
   "name": "@folio/stripes-connect",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "description": "Declarative REST data access for React components",
   "repository": "folio-org/stripes-connect",
-  "sideEffects": ["*.css"],
+  "sideEffects": [
+    "*.css"
+  ],
   "publishConfig": {
     "registry": "https://repository.folio.org/repository/npm-folio/"
   },


### PR DESCRIPTION
This PR is an attempt to fix issues described in https://issues.folio.org/browse/STCON-48, https://issues.folio.org/browse/STCON-49 and https://issues.folio.org/browse/STCON-80 

Instead of relying on the path template we can actually use the processed path (passed as a metadata).

The change proposed here should be backwards compatible with the previous implementation. 

