### PR TITLE
Prevent crash when verbOptions returns null

### DIFF
--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -631,8 +631,11 @@ export default class RESTResource {
   accFetch = (paramOpts, props) => {
     const key = this.stateKey();
     return (dispatch, getState) => {
-      const options = Object.assign(this.verbOptions('GET', getState(), props), paramOpts);
+      let options = this.verbOptions('GET', getState(), props);
       if (options === null) return null; // needs dynamic parts that aren't available
+
+      options = Object.assign(options, paramOpts);
+
       const url = urlFromOptions(options);
       if (url === null) return null;
       const { headers, records } = options;


### PR DESCRIPTION
An undefined param was crashing Stripes when the `NotesSmartAccordion` was attempting to fetch notes. Debugged it to this line where it'd try to assign to a `null` value that was being returned from `this.verbOptions()`.