### PR TITLE
Refresh resource with interpolated property when the prop changes. Fixes STCON-81.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 5.3.0 (IN PROGRESS)
 
 * The `records` parameter of a REST-resource manifest may now be multi-level as in `'records.value'`. Available from v5.2.2.
+* Refresh resource with interpolated property when the prop changes. Fixes STCON-81.
 
 ## [5.2.1](https://github.com/folio-org/stripes-connect/tree/v5.2.1) (2019-06-07)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v5.2.0...v5.2.1)

--- a/LocalResource.js
+++ b/LocalResource.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import { isEqual, snakeCase } from 'lodash';
 
 export default class LocalResource {
   constructor(name, query = {}, module = null, logger, dataKey) {
@@ -34,7 +34,7 @@ export default class LocalResource {
     },
   })
 
-  stateKey = () => `${this.dataKey ? `${this.dataKey}#` : ''}${_.snakeCase(this.module)}_${this.name}`;
+  stateKey = () => `${this.dataKey ? `${this.dataKey}#` : ''}${snakeCase(this.module)}_${this.name}`;
 
   reducer = (state = this.query.initialValue !== undefined ? this.query.initialValue : {}, action) => {
     if (action.meta !== undefined &&
@@ -55,5 +55,10 @@ export default class LocalResource {
     } else {
       return state;
     }
+  }
+
+  shouldRefresh(props, nextProps) {
+    const key = this.name;
+    return !isEqual(props.resources[key], nextProps.resources[key]);
   }
 }

--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -331,6 +331,15 @@ export default class RESTResource {
     return `${this.dataKey ? `${this.dataKey}#` : ''}${this.crudName}`;
   }
 
+  shouldRefresh(props, nextProps) {
+    const { root: { store } } = props;
+    const state = store.getState();
+    const opts = this.verbOptions('GET', state, props);
+    const nextOpts = this.verbOptions('GET', state, nextProps);
+
+    return opts && nextOpts && opts.path !== nextOpts.path;
+  }
+
   refresh(dispatch, props) {
     const opt = this.optionsTemplate;
     if (opt.accumulate === true

--- a/connect.js
+++ b/connect.js
@@ -129,8 +129,9 @@ const wrap = (Wrapped, module, epics, logger, options = {}) => {
         if (resource instanceof LocalResource) {
           const same = _.isEqual(data[key], nextProps.resources[key]);
           if (!same) return true;
-        } else if (resource instanceof OkapiResource) {
-          return resource.shouldRefresh(this.props, nextProps);
+        } else if (resource instanceof OkapiResource
+          && resource.shouldRefresh(this.props, nextProps)) {
+          return true;
         }
       }
       return false;


### PR DESCRIPTION
The refresh was not handled for resources with paths defined as `!{prop}`. This PR should address it.

https://issues.folio.org/browse/STCON-81
