### PR TITLE
Pass props into params function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 5.3.0 (IN PROGRESS)
 
 * The `records` parameter of a REST-resource manifest may now be multi-level as in `'records.value'`. Available from v5.2.2.
+* When a params function is invoked, the props of the component using stripes-connect are now passed as a fifth parameter. Available from v5.2.3.
 
 ## [5.2.1](https://github.com/folio-org/stripes-connect/tree/v5.2.1) (2019-06-07)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v5.2.0...v5.2.1)

--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -262,7 +262,7 @@ export default class RESTResource {
         }
       } else if (typeof options.params === 'function') {
         const parsedQuery = queryString.parse(_.get(props, ['location', 'search']));
-        options.params = options.params(parsedQuery, _.get(props, ['match', 'params']), mockProps(state, this.module, props.dataKey, this.logger).resources, this.logger);
+        options.params = options.params(parsedQuery, _.get(props, ['match', 'params']), mockProps(state, this.module, props.dataKey, this.logger).resources, this.logger, props);
       }
 
       // recordsRequired

--- a/doc/api.md
+++ b/doc/api.md
@@ -379,7 +379,8 @@ When the power and flexibility of text substitution and fallbacks are not
 sufficient for expressing how to build the back-end UI, arbitrary
 JavaScript can be used instead. If the value of a resource's `path` or one
 of its `params` is a function rather than a string, then that function is
-invoked whenever a path is needed. It is passed three parameters:
+invoked whenever a path is needed. It is passed five parameters
+(though most functions will not use them all):
 
 * An object containing the UI URL's query parameters (as accessed by
   `?{name}`).
@@ -389,6 +390,12 @@ invoked whenever a path is needed. It is passed three parameters:
 
 * An object containing the component's resources' data (as accessed by
   `%{name}`).
+
+* The logger object in use by stripes-connect.
+
+* The entire set of props of the component using stripes-connect
+  (which of course contains redundant copies of much of the rest of
+  the information passed in).
 
 The function must return a string to use as the path, or `null`
 if it is unable to do this because a required piece of state is

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-connect",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "description": "Declarative REST data access for React components",
   "repository": "folio-org/stripes-connect",
   "sideEffects": [


### PR DESCRIPTION
This allows `getSASparams` to pass the props into a `queryGetter` function, so that the application can consult the props dynamically to determine how to massage the query within a static manifest.