### PR TITLE
RESTResource: Refresh when params change

### DIFF
--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -337,7 +337,10 @@ export default class RESTResource {
     const opts = this.verbOptions('GET', state, props);
     const nextOpts = this.verbOptions('GET', state, nextProps);
 
-    return opts && nextOpts && opts.path !== nextOpts.path;
+    return (
+      opts && nextOpts &&
+      (opts.path !== nextOpts.path || !_.isEqual(opts.params, nextOpts.params))
+    );
   }
 
   refresh(dispatch, props) {


### PR DESCRIPTION
Resources don't get refreshed when query params change. This fixes that.