### PR TITLE
An attempt to improve form performance. Part of FOLIO-2158

### DIFF
--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -331,9 +331,7 @@ export default class RESTResource {
     return `${this.dataKey ? `${this.dataKey}#` : ''}${this.crudName}`;
   }
 
-  shouldRefresh(props, nextProps) {
-    const { root: { store } } = props;
-    const state = store.getState();
+  shouldRefresh(props, nextProps, state) {
     const opts = this.verbOptions('GET', state, props);
     const nextOpts = this.verbOptions('GET', state, nextProps);
 

--- a/connect.js
+++ b/connect.js
@@ -17,17 +17,11 @@ const types = {
   rest: RESTResource,
 };
 
-function filterProps(props) {
-  const filtered = {};
-
-  _.forOwn(props, (prop, key) => {
-    if (!_.isFunction(prop) &&
-      !_.includes(['anyTouched', 'mutator', 'connectedSource'], key)) {
-      filtered[key] = prop;
-    }
-  });
-
-  return filtered;
+function arePropsEqual(props, prevProps) {
+  return _.isEqualWith(props, prevProps, _.after(2, (p1, p2, key) => {
+    if (_.isFunction(p1) || _.isFunction(p2) ||
+    _.includes(['anyTouched', 'mutator', 'connectedSource'], key)) return true;
+  }));
 }
 
 const wrap = (Wrapped, module, epics, logger, options = {}) => {
@@ -133,11 +127,7 @@ const wrap = (Wrapped, module, epics, logger, options = {}) => {
       // a refresh? See STRIPES-393. For now, we do this when the UI URL
       // or any local resource has changed.
       if (nextProps.location !== this.props.location) return true;
-
-      const cleanProps = filterProps(this.props);
-      const cleanNextProps = filterProps(nextProps);
-
-      if (_.isEqual(cleanProps, cleanNextProps)) return false;
+      if (arePropsEqual(this.props, nextProps)) return false;
 
       for (let i = 0, size = resources.length; i < size; ++i) {
         if (resources[i].shouldRefresh(this.props, nextProps)) {

--- a/connect.js
+++ b/connect.js
@@ -17,6 +17,19 @@ const types = {
   rest: RESTResource,
 };
 
+function filterProps(props) {
+  const filtered = {};
+
+  _.forOwn(props, (prop, key) => {
+    if (!_.isFunction(prop) &&
+      !_.includes(['anyTouched', 'mutator', 'connectedSource'], key)) {
+      filtered[key] = prop;
+    }
+  });
+
+  return filtered;
+}
+
 const wrap = (Wrapped, module, epics, logger, options = {}) => {
   const resources = [];
   const dataKey = options.dataKey;
@@ -121,8 +134,13 @@ const wrap = (Wrapped, module, epics, logger, options = {}) => {
       // or any local resource has changed.
       if (nextProps.location !== this.props.location) return true;
 
-      for (const resource of resources) {
-        if (resource.shouldRefresh(this.props, nextProps)) {
+      const cleanProps = filterProps(this.props);
+      const cleanNextProps = filterProps(nextProps);
+
+      if (_.isEqual(cleanProps, cleanNextProps)) return false;
+
+      for (let i = 0, size = resources.length; i < size; ++i) {
+        if (resources[i].shouldRefresh(this.props, nextProps)) {
           return true;
         }
       }

--- a/connect.js
+++ b/connect.js
@@ -17,7 +17,7 @@ const types = {
   rest: RESTResource,
 };
 
-const excludedProps = ['anyTouched', 'mutator', 'connectedSource', 'resources'];
+const excludedProps = ['anyTouched', 'mutator', 'connectedSource'];
 
 // Check if props are equal by first filtering out props which are functions
 // or common props introduced by stripes-connect or redux-form


### PR DESCRIPTION
It looks like redux-form is causing an update of the connected parent components every time we type of focus on given for elements.

This PR is trying to limit the number of times we check if the resources should be refreshed by first checking if the props actually differ. 

