### PR TITLE
Add couple more performance improvements. Part of FOLIO-2158

### DIFF
--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -333,17 +333,14 @@ export default class RESTResource {
 
   // check if the given manifest has a path with
   // the property namespace !{syntax} or if path or params are functions
+  // or if params is an object with values which contain the property namespace
   hasPropNamespace = _.memoize(() => {
-    const optsTmpl = _.merge({}, this.optionsTemplate, this.optionsTemplate.GET);
+    const { path, params } = _.merge({}, this.optionsTemplate, this.optionsTemplate.GET);
+    const ns = '!{';
 
-    if (!_.isFunction(optsTmpl.path) &&
-      !_.isFunction(optsTmpl.params) &&
-      optsTmpl.path &&
-      !optsTmpl.path.match('!{')) {
-      return false;
-    }
-
-    return true;
+    return (_.isString(path) && path.match(ns)) ||
+      _.isFunction(path) || _.isFunction(params) ||
+      (_.isObject(params) && !_.isEmpty(_.pickBy(params, param => _.isString(param) && param.match(ns))));
   });
 
   shouldRefresh(props, nextProps, state) {

--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -196,10 +196,6 @@ export default class RESTResource {
     return actions;
   }
 
-  getOptionsTemplate(verb) {
-    return Object.assign({}, this.optionsTemplate, this.optionsTemplate[verb]);
-  }
-
   // We should move optionsFromState to OkapiResource and override this there
   verbOptions = (verb, state, props) => {
     const options = _.merge({},

--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -26,41 +26,6 @@ function extractTotal(json) {
   return null;
 }
 
-// The following fallback syntax is one small part of what Bash
-// implements -- see the "Parameter Expansion" section of its
-// manual. It's the part we need right now, but we should consider
-// implementing all of it. And needless to say, it should apply to all
-// kinds of substitutable.
-//
-function processFallback(s, getPath, props) {
-  let name = s;
-  let type;
-  let val;
-
-  const re = /(.*?):([+-])(.*)/.exec(name);
-  if (re) {
-    name = re[1];
-    type = re[2];
-    val = re[3];
-    // console.log(`'${s}' matched fallback syntax: name='${name}', type='${type}', val='${val}'`);
-  }
-  let res = _.get(props, [].concat(getPath).concat(name), null);
-  if (type === '+') {
-    if (res !== null) {
-      // console.log(`got value for name '${name}': replaced by '${val}'`);
-      res = val;
-    } else {
-      // console.log(`no value for name '${name}': setting empty`);
-      res = '';
-    }
-  }
-  if (res === null && type === '-') {
-    // console.log(`no value for name '${name}': replaced by '${val}'`);
-    res = val;
-  }
-  return res;
-}
-
 // Calculate what the props _would be_ if we went through
 // mapStateToProps. If dataKey is included, then we look only at state
 // pertaining to that data-key.
@@ -142,22 +107,22 @@ export function compilePathTemplate(template, parsedQuery, props, localProps) {
   const result = template.replace(/([?:$%!]){(.*?)}/g, (match, ns, name) => {
     switch (ns) {
       case '?': {
-        const queryParam = processFallback(name, [], parsedQuery);
+        const queryParam = _.get(parsedQuery, name, null);
         if (queryParam === null) dynamicPartsSatisfied = false;
         return queryParam;
       }
       case ':': {
-        const pathComp = processFallback(name, ['match', 'params'], props);
+        const pathComp = _.get(props, `match.params.${name}`, null);
         if (pathComp === null) dynamicPartsSatisfied = false;
         return pathComp;
       }
       case '%': case '$': {
-        const localState = processFallback(name.split('.'), [], localProps);
+        const localState = _.get(localProps, name, null);
         if (localState === null) dynamicPartsSatisfied = false;
         return localState;
       }
       case '!': {
-        const prop = processFallback(name.split('.'), [], props);
+        const prop = _.get(props, name, null);
         if (prop === null) dynamicPartsSatisfied = false;
         return prop;
       }
@@ -167,6 +132,7 @@ export function compilePathTemplate(template, parsedQuery, props, localProps) {
       }
     }
   });
+
   return dynamicPartsSatisfied ? result : null;
 }
 
@@ -228,6 +194,10 @@ export default class RESTResource {
       });
     }
     return actions;
+  }
+
+  getOptionsTemplate(verb) {
+    return Object.assign({}, this.optionsTemplate, this.optionsTemplate[verb]);
   }
 
   // We should move optionsFromState to OkapiResource and override this there
@@ -331,7 +301,26 @@ export default class RESTResource {
     return `${this.dataKey ? `${this.dataKey}#` : ''}${this.crudName}`;
   }
 
+  // check if the given manifest has a path with
+  // the property namespace !{syntax} or if path or params are functions
+  hasPropNamespace = _.memoize(() => {
+    const optsTmpl = _.merge({}, this.optionsTemplate, this.optionsTemplate.GET);
+
+    if (!_.isFunction(optsTmpl.path) &&
+      !_.isFunction(optsTmpl.params) &&
+      optsTmpl.path &&
+      !optsTmpl.path.match('!{')) {
+      return false;
+    }
+
+    return true;
+  });
+
   shouldRefresh(props, nextProps, state) {
+    if (!this.hasPropNamespace()) {
+      return false;
+    }
+
     const opts = this.verbOptions('GET', state, props);
     const nextOpts = this.verbOptions('GET', state, nextProps);
 


### PR DESCRIPTION
This PR includes couple more performance improvements mentioned on Slack by @MikeTaylor and @zburke. 

It basically checks if the given resource has a property namespace `!{syntax}` defined as a path or if path or params are defined as functions. In other cases the refresh will be skipped. 