### PR TITLE
Added PRUNE Redux action

### DIFF
--- a/RESTResource/reducer.js
+++ b/RESTResource/reducer.js
@@ -46,6 +46,11 @@ export default function (state = initialResourceState, action) {
         ...action.meta,
       });
     }
+    case '@@stripes-connect/PRUNE': {
+      return Object.assign({}, state, {
+        records: [],
+      });
+    }
     case '@@stripes-connect/RESET': {
       return initialResourceState;
     }


### PR DESCRIPTION
This is to address https://issues.folio.org/browse/UIIN-687 where performance slowly degrades over long periods of time. 

The approach here is to reset stored records when moving between modules since they do take up space in memory and can grow unbounded as you visit more modules and run additional searches. By calling PRUNE whenever switching modules, we ensure that at most only 1 set of records is stored in Redux at any given time, thus making memory usage more reasonable and more predictable. 

We will still be retaining search queries and other light pieces of metadata in Redux, so when moving back to a previously accessed module, the search is quickly re-run adding only a slight pause in user experience.