### PR TITLE
Added cache array to connect

### DIFF
--- a/connect.js
+++ b/connect.js
@@ -18,6 +18,7 @@ const types = {
 };
 
 const excludedProps = ['anyTouched', 'mutator', 'connectedSource'];
+let _registeredEpics = [];
 
 // Check if props are equal by first filtering out props which are functions
 // or common props introduced by stripes-connect or redux-form
@@ -36,7 +37,13 @@ const wrap = (Wrapped, module, epics, logger, options = {}) => {
     const resource = new types[query.type || defaultType](name, query, module, logger, query.dataKey || dataKey);
     resources.push(resource);
     if (query.type === 'okapi') {
-      epics.add(...mutationEpics(resource), refreshEpic(resource));
+      const key = `${resource.name}${resource.module}`;
+      // Only register each module component once since mutator only needs a single reference, otherwise the
+      // mutations continue to be added when modules are re-connected causing performance issues.
+      if (!_.includes(_registeredEpics, key)) {
+        _registeredEpics.push(key);
+        epics.add(...mutationEpics(resource));
+      }
     }
   });
 
@@ -105,6 +112,9 @@ const wrap = (Wrapped, module, epics, logger, options = {}) => {
       this.props.refreshRemote({ ...this.props });
       resources.forEach((resource) => {
         if (resource instanceof OkapiResource) {
+          // Call refresh whenever mounting to ensure that mutated data is updated in the UI.
+          // This is safe to call as many times as needed when re-connecting.
+          epics.add(refreshEpic(resource));
           resource.markVisible();
         }
       });


### PR DESCRIPTION
so that mutationEpics only adds a given resource reference once per module action. Otherwise, the references pile up causing a significant performance issue.

I ran the following test to compare run times (which conveniently track against the /item PUT call to okapi in this case):

1. Navigate to Inventory.
2. Search, open an instance, then select a holding.
3. Click edit, make a change, and then save.
4. Navigate to 3 other modules (Request, Codex search, and Users), then return to Inventory.
5. Close the current holding, then open a different holding.
6. Repeat steps 3-5.

Before:

![Screen Shot 2019-10-04 at 5 07 48 PM](https://user-images.githubusercontent.com/28395235/66240523-df8f3f00-e6ca-11e9-85a1-1a9cd8b91fe5.png)

After:

![Screen Shot 2019-10-04 at 5 19 27 PM](https://user-images.githubusercontent.com/28395235/66240614-2715cb00-e6cb-11e9-8407-acd9311bb473.png)
