### PR TITLE
RESTResource: shouldRefresh when `fetch` goes true

### DIFF
--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -351,9 +351,16 @@ export default class RESTResource {
     const opts = this.verbOptions('GET', state, props);
     const nextOpts = this.verbOptions('GET', state, nextProps);
 
+    const fetch = typeof opts.fetch === 'function' ? opts.fetch(props) : opts.fetch;
+    const nextFetch = typeof nextOpts.fetch === 'function' ? nextOpts.fetch(nextProps) : nextOpts.fetch;
+
     return (
       opts && nextOpts &&
-      (opts.path !== nextOpts.path || !_.isEqual(opts.params, nextOpts.params))
+      (
+        opts.path !== nextOpts.path ||
+        !_.isEqual(opts.params, nextOpts.params) ||
+        (!fetch && nextFetch)
+      )
     );
   }
 


### PR DESCRIPTION
When using the `fetch` property on a resource, the resource may never get fetched.

For example, here's a manifest:
```
  static manifest = Object.freeze({
    logs: {
      type: 'okapi',
      path: 'erm/jobs/!{job.id}/!{type}Log',
      fetch: props => props.fetch,
    },
  });
```

I want to lazy-load this endpoint. Ie, only fetch this endpoint when an accordion is open because the fetch is very expensive. So initially, the `fetch` prop I pass in is `false`, and when the accordion opens, it becomes `true`. However, because the `path` or `params` haven't changed, `shouldRefresh` returns `false`. As a result, this endpoint is never fetched.

I don't like the idea of ballooning this function, but:
- Most containers don't use functional `fetch`, so this check should be quite fast on average.
- The workaround is to do something dirty like putting `fetch` into my resource's `params` to trick `shouldRefresh`. This is ugly.

I'm definitely willing to hear alternatives to this.