### PR TITLE
Add ability to clear registered epics. Part of STRIPES-659

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-connect
 
+## 5.4.2 IN PROGRESS
+
+* Add ability to clear registered epics. Part of STRIPES-659.
+
 ## [5.4.1](https://github.com/folio-org/stripes-connect/tree/v5.4.1) (2019-10-08)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v5.4.0...v5.4.1)
 

--- a/connect.js
+++ b/connect.js
@@ -18,7 +18,7 @@ const types = {
 };
 
 const excludedProps = ['anyTouched', 'mutator', 'connectedSource'];
-const _registeredEpics = {};
+let _registeredEpics = {};
 
 // Check if props are equal by first filtering out props which are functions
 // or common props introduced by stripes-connect or redux-form
@@ -228,4 +228,7 @@ export const connectFor = (module, epics, logger) => (Component, options) => con
 
 export { default as ConnectContext, withConnect } from './ConnectContext';
 
+export function clearRegisteredEpics() {
+  _registeredEpics = {};
+}
 export default connect;

--- a/connect.js
+++ b/connect.js
@@ -228,7 +228,7 @@ export const connectFor = (module, epics, logger) => (Component, options) => con
 
 export { default as ConnectContext, withConnect } from './ConnectContext';
 
-export function clearRegisteredEpics() {
+export function reset() {
   _registeredEpics = {};
 }
 export default connect;


### PR DESCRIPTION
https://issues.folio.org/browse/STRIPES-659

We need a way to clear registered epics during the BigTest app `teardown` process:

https://github.com/folio-org/stripes-core/blob/master/test/bigtest/helpers/setup-application.js#L68

This is required because every time a new instance of the `App` is created we also initialize epics (a new instance of BehaviorSubject is created):

https://github.com/folio-org/stripes-core/blob/master/src/App.js#L32
https://github.com/folio-org/stripes-core/blob/master/src/configureEpics.js#L12

When this happens  the previously registered epics become stale. 

This PR exposes a new function via `connect` called `reset` which can be used in the BigTest `teardown` hook to clear the epics.
