### PR TITLE
avoid Error: Uncaught TypeError: Cannot read property 'fetch' of null

### DIFF
--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -351,8 +351,8 @@ export default class RESTResource {
     const opts = this.verbOptions('GET', state, props);
     const nextOpts = this.verbOptions('GET', state, nextProps);
 
-    const fetch = typeof opts.fetch === 'function' ? opts.fetch(props) : opts.fetch;
-    const nextFetch = typeof nextOpts.fetch === 'function' ? nextOpts.fetch(nextProps) : nextOpts.fetch;
+    const fetch = opts && (typeof opts.fetch === 'function' ? opts.fetch(props) : opts.fetch);
+    const nextFetch = nextOpts && (typeof nextOpts.fetch === 'function' ? nextOpts.fetch(nextProps) : nextOpts.fetch);
 
     return (
       opts && nextOpts &&


### PR DESCRIPTION
this causes issues in tests for ui-finance: https://jenkins-aws.indexdata.com/job/folio-org/job/ui-finance/job/PR-166/6/console
If you look into `this.verbOptions()` you'll find that result might be `null`. So it's better to check this.