### PR TITLE
Revert "Added PRUNE Redux action"

### DIFF
--- a/RESTResource/reducer.js
+++ b/RESTResource/reducer.js
@@ -46,11 +46,6 @@ export default function (state = initialResourceState, action) {
         ...action.meta,
       });
     }
-    case '@@stripes-connect/PRUNE': {
-      return Object.assign({}, state, {
-        records: [],
-      });
-    }
     case '@@stripes-connect/RESET': {
       return initialResourceState;
     }


### PR DESCRIPTION
Reverts folio-org/stripes-connect#102

Reverting in light of [STCOR-392](https://issues.folio.org/browse/STCOR-392). **Must be merged after folio-org/stripes-core/pull/735.** 

Technically, this is a breaking change and therefore merits a major version update. In practice, this was only called from one place and that's already been removed, so this won't have any effect, but, a break is a break. This update must include a change to `package.json` that updates the major version, or be merged on a next-major-version branch.