### PR TITLE
Introduce a way to reset resources with resourceShouldRefresh present when component unmounts. Refs UICIRC-365.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-connect
 
+## 5.4.3 (IN PROGRESS)
+
+* Introduce a way to reset resources with `resourceShouldRefresh` present when component unmounts. Refs UICIRC-365.
+
 ## [5.4.2](https://github.com/folio-org/stripes-connect/tree/v5.4.2) (2019-10-15)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v5.4.1...v5.4.2)
 

--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -381,6 +381,21 @@ export default class RESTResource {
     this.dispatch(this.fetchAction(this.cachedProps));
   }
 
+  // Check if the given resource should be reset when a connected
+  // component is being unmounted.
+  shouldReset() {
+    const { resourceShouldRefresh } = this.optionsTemplate;
+
+    return (_.isBoolean(resourceShouldRefresh) && resourceShouldRefresh)
+      || (_.isFunction(resourceShouldRefresh) && resourceShouldRefresh());
+  }
+
+  // resets redux store attached to this resource
+  reset() {
+    if (!this.dispatch) return;
+    this.dispatch(this.actions.reset());
+  }
+
   hasMissingPerms(state, perms) {
     const currentPerms = _.get(state, ['okapi', 'currentPerms'], {});
     const reqPerms = _.isArray(perms) ? perms : perms.split(',');

--- a/connect.js
+++ b/connect.js
@@ -132,6 +132,10 @@ const wrap = (Wrapped, module, epics, logger, options = {}) => {
       resources.forEach((resource) => {
         if (resource instanceof OkapiResource) {
           resource.markInvisible();
+
+          if (resource.shouldReset()) {
+            resource.reset();
+          }
         }
       });
     }


### PR DESCRIPTION
This PR is an idea from @zburke based on the issue found in https://github.com/folio-org/ui-circulation/pull/474

There are some cases where remounted connected components render stale data. In most cases that's fine but when the  `resourceShouldRefresh` is present the expectation is to receive a fresh data when the component is remounted / reconnected.