### PR TITLE
Init resource data correctly

### DIFF
--- a/RESTResource/reducer.js
+++ b/RESTResource/reducer.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 
-const initialResourceState = {
+export const initialResourceState = {
   hasLoaded: false,
   isPending: false,
   failed: false,

--- a/connect.js
+++ b/connect.js
@@ -6,6 +6,7 @@ import { withConnect } from './ConnectContext';
 
 import OkapiResource from './OkapiResource';
 import RESTResource from './RESTResource';
+import { initialResourceState } from './RESTResource/reducer';
 import LocalResource from './LocalResource';
 import { mutationEpics, refreshEpic } from './epics';
 
@@ -179,8 +180,17 @@ const wrap = (Wrapped, module, epics, logger, options = {}) => {
     logger.log('connect-lifecycle', `mapState for <${Wrapped.name}>, resources =`, resources);
 
     const resourceData = {};
+
     for (const r of resources) {
-      resourceData[r.name] = Object.freeze(_.get(state, [`${r.stateKey()}`], null));
+      let initState = _.get(state, r.stateKey());
+
+      if (!initState) {
+        initState = (r instanceof OkapiResource)
+          ? initialResourceState
+          : _.get(r, 'query.initialValue', null);
+      }
+
+      resourceData[r.name] = Object.freeze(initState);
     }
 
     const newProps = { dataKey, resources: resourceData };


### PR DESCRIPTION
This PR initializes resource data with the correct structure which makes it available during the first render.

Instead of doing:

`get('resources', 'resourceName.records', [])`;

resources structure will be always present:

`resources.resourceName.records`

This change should be part of the next major release.