### PR TITLE
STCON-90 gracefully handle paging requests based on bad totalRecords estimates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change history for stripes-connect
 
+## [5.4.4](https://github.com/folio-org/stripes-connect/tree/v5.4.4) (2019-12-11)
+[Full Changelog](https://github.com/folio-org/stripes-connect/compare/v5.4.3...v5.4.4)
+
+* Avoid executing `pageSuccess` during pagination if the `totalRecords` are not present. Refs STSMACOM-259.
+
 ## [5.4.3](https://github.com/folio-org/stripes-connect/tree/v5.4.3) (2019-12-04)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v5.4.2...v5.4.3)
 

--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -661,7 +661,23 @@ export default class RESTResource {
                   httpStatus: response.status,
                   other: records ? _.omit(json, records) : {},
                 };
-                if (meta.other) meta.other.totalRecords = extractTotal(json);
+
+                if (meta.other) {
+                  const totalRecords = extractTotal(json);
+                  // Please see https://issues.folio.org/browse/STSMACOM-259
+                  // for more details.
+
+                  // The totalRecords returned from the backend are sometimes
+                  // incorrect and instead of returning the actual number they
+                  // return 999999 which causes an extra fetch which in turn
+                  // returnes empty result. This is a workaround for this issue.
+                  if (totalRecords === 0) {
+                    return;
+                  }
+
+                  meta.other.totalRecords = totalRecords;
+                }
+
                 const data = (records ? json[records] : json);
                 dispatch(this.actions.pageSuccess(meta, data));
               });

--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -318,6 +318,32 @@ export default class RESTResource {
             return acc.concat(Object.assign({}, val,
               { isComplete: true, records: action.payload, meta: action.meta }));
           }
+
+          // Handle the situation where we accidentally ask for more pages
+          // than there are in the set, i.e. we query for offset=120 when
+          // there are only 100 records in a set. Why, why would we issue
+          // such a query? It's complicated.
+          //
+          // In short, calculating the size of result sets can be expensive,
+          // so there's a heuristic, but sometimes it's very, very, VERY wrong.
+          // When Okapi thinks the result set will contain > 10k rows, it
+          // returns totalCount=999999999 to indicate "Ah'm just guessin'
+          // because the real number is wicked huge." The problem is that if
+          // we start paging through one of these supposedly-wicked-huge
+          // result sets and fall off the end of it, we'll then get response
+          // with totalCount=0.
+          //
+          // When we receive totalCount=0 in the middle of paging, we dispatch
+          // a success, but with an added meta property the allows us to figure
+          // out what on earth just happened, dropping you here.
+          //
+          // So this is how it is: all we need to do here is set
+          // isComplete=true. The rest of the work has already been done.
+          //
+          if (action.meta.bonkersOkapiCannotCount) {
+            return acc.concat(Object.assign({}, val, { isComplete: true }));
+          }
+
           return acc.concat(val);
         }, []);
         return newState;
@@ -664,18 +690,20 @@ export default class RESTResource {
 
                 if (meta.other) {
                   const totalRecords = extractTotal(json);
-                  // Please see https://issues.folio.org/browse/STSMACOM-259
-                  // for more details.
 
-                  // The totalRecords returned from the backend are sometimes
-                  // incorrect and instead of returning the actual number they
-                  // return 999999 which causes an extra fetch which in turn
-                  // returns an empty result. This is a workaround for this issue.
+                  // if we receive totalRecords = 0 in the middle of paging,
+                  // it's because we got an initial bad estimate from okapi
+                  // and fell off the end of the result set.
+                  //
+                  // additional detals at https://issues.folio.org/browse/STSMACOM-259
+                  //
+                  // here, we'll dispatch a success action, but with a flag
+                  // that allows the reducer to handle that gracefully.
                   if (totalRecords === 0) {
-                    return;
+                    meta.bonkersOkapiCannotCount = true;
+                  } else {
+                    meta.other.totalRecords = totalRecords;
                   }
-
-                  meta.other.totalRecords = totalRecords;
                 }
 
                 const data = (records ? json[records] : json);

--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -691,11 +691,11 @@ export default class RESTResource {
                 if (meta.other) {
                   const totalRecords = extractTotal(json);
 
-                  // if we receive totalRecords = 0 in the middle of paging,
+                  // if we receive totalRecords === 0 in the middle of paging,
                   // it's because we got an initial bad estimate from okapi
                   // and fell off the end of the result set.
                   //
-                  // additional detals at https://issues.folio.org/browse/STSMACOM-259
+                  // additional details at https://issues.folio.org/browse/STSMACOM-259
                   //
                   // here, we'll dispatch a success action, but with a flag
                   // that allows the reducer to handle that gracefully.

--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -670,7 +670,7 @@ export default class RESTResource {
                   // The totalRecords returned from the backend are sometimes
                   // incorrect and instead of returning the actual number they
                   // return 999999 which causes an extra fetch which in turn
-                  // returnes empty result. This is a workaround for this issue.
+                  // returns an empty result. This is a workaround for this issue.
                   if (totalRecords === 0) {
                     return;
                   }


### PR DESCRIPTION
When paging ends unexpectedly because Okapi goes from returning
`totalRecords=999999999` to e.g. `totalRecords=100`, an extra request
will be triggered that will receive `totalRecords=0`. When this happens,
we need still need to trigger a PAGE_SUCCESS event to indicate that
paging has ended, but we need to do so _without_ resetting the final
record count to 0.

Yeah, it's a bit messy. Additional details in the comments.

Refs [STSMACOM-259](https://issues.folio.org/browse/STSMACOM-259), [STCON-90](https://issues.folio.org/browse/STCON-90)
