### PR TITLE
STCON-91 reset paging cache on successful fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-connect
 
+## 5.4.5 IN-PROGRESS
+
+* Reset paging with a successful fetch. Resolves UIU-1405.
+
 ## [5.4.4](https://github.com/folio-org/stripes-connect/tree/v5.4.4) (2019-12-11)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v5.4.3...v5.4.4)
 

--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -653,6 +653,9 @@ export default class RESTResource {
                 dispatch(this.fetchMore(options, total, data, meta));
               } else {
                 dispatch(this.actions.fetchSuccess(meta, data));
+                // restart paging if there is any, otherwise any cached pages will
+                // populate the UI the next time the connected component mounts.
+                dispatch(this.actions.pageStart());
               }
             });
           }


### PR DESCRIPTION
## Problem
PO reports of results list populating with unrequested results when only one result was present before - this would happen when clicking through to details or returning from an edit view (ui-users).

This can be  reproduced if you check a filter, get results, and then enter a search string in `ui-users` and click search (reducing the results list to one.) Once you click on the details page, the result list will fill up again (as if produced by the filter alone.)

This was the result of cached paging data still left in the redux store.

The paged cache would be passed on as a fetch success when a connected component was re-instantiated due to https://github.com/folio-org/stripes-connect/blob/master/connect.js#L91

I don't know if this is the solid solution - but it wouldn't surprise me if this has been the culprit of some other issues we've faced.

## Approach
Call the `pagingStart` action to reset the paging key on the store when a fetch is successful.