### PR TITLE
STCON-92: PUT mutator returns server response if avail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Reset paging with a successful fetch. Resolves UIU-1405.
 * Added support for fetching result list pages individually by offset. See migration path [documentation](MIGRATIONPATHS.md). Refs STCON-57.
+* PUT mutator returns the server's response when it is JSON rather than the client record. Refs STCON-92.
 
 ## [5.4.4](https://github.com/folio-org/stripes-connect/tree/v5.4.4) (2019-12-11)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v5.4.3...v5.4.4)


### PR DESCRIPTION
Some backends respond with the updated record when returning from a PUT endpoint. This is especially useful when the backend doesn't persist the record as-is, but adds/removes some properties such as nested ids.

In those scenarios, the only way to get the canonical record is to either:
1. Do ugly `componentDidUpdate` (or similar) checks for if the component's `resources` changed.
1. Manually chain on a call to the GET mutator.

Both of these patterns are discouraged in general, so this provides a saner option where the backend's response is returned from the PUT if it's JSON.

If the backend's response _is not_ JSON, then the behaviour doesn't change; we continue to respond with the `clientRecord` that was sent to the backend.