### PR TITLE
Set hasLoaded to false on a FETCH_START action

### DIFF
--- a/RESTResource/reducer.js
+++ b/RESTResource/reducer.js
@@ -18,7 +18,7 @@ export default function (state = initialResourceState, action) {
 
   switch (action.type) {
     case '@@stripes-connect/FETCH_START': {
-      return Object.assign({}, state, { isPending: true });
+      return Object.assign({}, state, { hasLoaded: false, isPending: true });
     }
     case '@@stripes-connect/FETCH_SUCCESS': {
       let records;


### PR DESCRIPTION
The `hasLoaded` property seems to not toggle on subsequent fetches on a resource. It just toggles the first time from the `initialResourceState` of `false` to `true` and stays there. We should be returning `hasLoaded: false` in the state when the `FETCH_START` action is dispatched, so that this property can be used to wait, for example: load a spinner, while the fetch is still under process.  

This PR handles that.