### PR TITLE
Added warnings in docs for resultOffset

### DIFF
--- a/MIGRATIONPATHS.md
+++ b/MIGRATIONPATHS.md
@@ -3,7 +3,7 @@
 Upcoming release.
 
 ### A new way to request result list pages by offset is available
-You can now request an individual result list page using an offset, rather than by increasing the `resultCount` which re-requests all previously fetched pages. In order to opt-in to this new workflow, the following props need to be passed in: 
+You can now request an individual result list page using an offset, rather than by increasing the `resultCount` which re-requests all previously fetched pages. In order to opt-in to this new workflow, the following props need to be passed in:
 
 You also need to add the following property to `manifest` to any routes component that is used for searching in your module: `resultOffset: '%{resultOffset}'`. For example, in ui-inventory the resulting `manifest` in ItemsRoute.js looks like this:
 
@@ -27,3 +27,5 @@ static manifest = Object.freeze(
       resultOffset: { initialValue: 0 },
       ...
 ```
+
+Importantly, when fetching results by offset, care should be taken to limit the possibility of making several requests at a time due to the possibility of the results coming in out of order. For that reason, if the results are being displayed in a `MultiColumnList` (or similar component with infinite-scroll capabilities), infinite scroll should be turned off. In `MultiColumnList`, this is accomplished by setting the `pagingType` prop to `click` rather than the default `scroll`.

--- a/doc/api.md
+++ b/doc/api.md
@@ -171,6 +171,13 @@ via limitParam/offsetParam.
 * `shouldRefresh`: An optional function which can be used to indicate if the
 given resource should be refreshed when another resource is mutated.
 
+* `resultOffset`: A number, interpolated string, or function indicating what offset
+  into the results list should be fetched. This is an optional workflow that allows
+  fetching of just the next page rather than re-requesting all pages. Note that this
+  workflow is not supported for infinite-scroll due to the risk of out-of-order pages.
+  For example, a `MultiColumnList` tied to a resource using `resultOffset` should have
+  its `pagingType` prop set to `click` rather than `scroll`.
+
 In addition to these principal pieces of configuration, which apply to
 all operations on the resource, these values can be overridden for
 specific HTTP operations: the entries `GET`, `POST`, `PUT`, `DELETE`


### PR DESCRIPTION
I was hoping to put a warning into the code so that we could log a `console.warning`, but it doesn't seem possible because the `pagingType` is available only in `MCLRenderer` while the `resultOffset` is in stripes-connect. :\

I figure this gives the most visibility to the gotcha.