### PR TITLE
UIU-1295: Provide `silent` option for the resource in order to trigger…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Reset paging with a successful fetch. Resolves UIU-1405.
 * Added support for fetching result list pages individually by offset. See migration path [documentation](MIGRATIONPATHS.md). Refs STCON-57.
 * PUT mutator returns the server's response when it is JSON rather than the client record. Refs STCON-92.
+* Introduce silent option to POST, PUT and DELETE mutators. Refs UIU-1295.
 
 ## [5.4.4](https://github.com/folio-org/stripes-connect/tree/v5.4.4) (2019-12-11)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v5.4.3...v5.4.4)

--- a/doc/api.md
+++ b/doc/api.md
@@ -519,6 +519,13 @@ obvious way by the POST, PUT and PATCH operations. For DELETE, the
 record need only contain the `id` field, so that it suffices to call
 `mutator.tenants.DELETE({ id: 43 })`.
 
+The POST, PUT and DELETE mutators optionally take a second `options` parameter.
+Currently the only option available is `silent`. The silent option can be used
+to indicate that the given mutation should not cause refresh on any corresponding
+resources. This is particually helpful when running multiple mutations in a batch
+mode when only the last mutation should actually cause the refresh to happen.
+Example usage: `mutator.tenants.DELETE({ id: 43 }, { silent: true })`.
+
 For the GET mutator method, i.e. when passing `accumulate: true` in the
 manifest, provide an updated `params` argument rather than an updated record, e.g.
 

--- a/epics/mutationEpics.js
+++ b/epics/mutationEpics.js
@@ -9,7 +9,7 @@ const actionNames = [
 export default function mutationEpics(resource) {
   return actionNames.map(actionName => (action$) => action$
     .ofType(`@@stripes-connect/${actionName}`)
-    .filter(action => action.meta.resource === resource.name)
+    .filter(action => action.meta.resource === resource.name && !action.meta.silent)
     .map(action => {
       let { meta: { path } } = action;
       path = path && path.replace(/[\/].*$/g, '');  // eslint-disable-line no-useless-escape


### PR DESCRIPTION
… update of resources after the set of identical resources has been completed.

## Purpose

Note, this is just POC to show that there is a problem in the current behavior with a kind of batch requests like change due date when there is an existing subscription somewhere in the system to the resource.

The idea of the `silent` option is to handle the case when a bunch of identical API requests should be made, like (changing the due date of multiple loans one by one from the UI).

In order to demonstrate its need, play around with [PR](https://github.com/folio-org/stripes-smart-components/pull/707). Because of [subscription](https://github.com/folio-org/ui-users/blob/master/src/routes/LoansListingContainer.js#L31) to the loans (`circulation/loans?query=(userId=:{id}) sortby id&limit=100000`) in ui-users, in the current situation after each update of change due date causes the follow up requests for whole list. With `silent` option enabled, only one follow up refresh request will be made with the last update request.

## Screenshots
Without silent (two requests, if there were 100 loans, it would end up with additional 100 requests):
<img width="844" alt="Screen Shot 2020-02-10 at 16 48 49" src="https://user-images.githubusercontent.com/40821852/74160347-ed7b4080-4c25-11ea-86c0-7bce8b9b44c7.png">

With silent (one request, if there were 100 loans, it would end up with only one additional request):
<img width="844" alt="Screen Shot 2020-02-10 at 16 51 50" src="https://user-images.githubusercontent.com/40821852/74160376-f835d580-4c25-11ea-8e84-143fcbaa8601.png">
