### PR TITLE
UIU-1295: Fix opts param in create action

### DIFF
--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -497,7 +497,7 @@ export default class RESTResource {
     };
   }
 
-  createAction = (record, props) => (dispatch, getState, opts) => {
+  createAction = (record, props, opts) => (dispatch, getState) => {
     const options = this.verbOptions('POST', getState(), { clientGeneratePk: true, ...props });
     const { pk, clientGeneratePk, headers } = options;
     const url = urlFromOptions(options);


### PR DESCRIPTION
This is a bug fix I introduced in https://github.com/folio-org/stripes-connect/pull/126
The `opts` param in `createAction` was passed in a wrong place.

Apologies for this @zburke. This is needed to correctly address 

https://issues.folio.org/browse/UIU-1299