### PR TITLE
STCON-57 support paged offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Change history for stripes-connect
 
-## [5.4.5](https://github.com/folio-org/stripes-connect/tree/v5.4.5) (2020-01-03)
-[Full Changelog](https://github.com/folio-org/stripes-connect/compare/v5.4.4...v5.4.5)
+## 5.5.0 (IN PROGRESS)
+
+* Added support for fetching result list pages individually by offset. See migration path [documentation](MIGRATIONPATHS.md). Refs STCON-57.
+
+## [5.4.3](https://github.com/folio-org/stripes-connect/tree/v5.4.3) (2019-12-04)
 
 * Reset paging with a successful fetch. Resolves UIU-1405 (STCON-91).
 

--- a/MIGRATIONPATHS.md
+++ b/MIGRATIONPATHS.md
@@ -1,0 +1,29 @@
+# Stripes-Connect Migration Paths
+## 5.4 to 5.5
+Upcoming release.
+
+### A new way to request result list pages by offset is available
+You can now request an individual result list page using an offset, rather than by increasing the `resultCount` which re-requests all previously fetched pages. In order to opt-in to this new workflow, the following props need to be passed in: 
+
+You also need to add the following property to `manifest` to any routes component that is used for searching in your module: `resultOffset: '%{resultOffset}'`. For example, in ui-inventory the resulting `manifest` in ItemsRoute.js looks like this:
+
+```
+static manifest = Object.freeze({
+    records: {
+      ...
+      resultOffset: '%{resultOffset}',
+      perRequest: 100,
+      path: 'inventory/instances',
+      ...
+```
+
+Also, note that `resultOffset` needs to be initialized with a default value where the module defines the base `manifest` as follows: `resultOffset: { initialValue: 0 }`. For example, in ui-inventory the base `manifest` in withData.js looks like this:
+
+```
+static manifest = Object.freeze(
+    Object.assign({}, WrappedComponent.manifest, {
+      ...
+      resultCount: { initialValue: INITIAL_RESULT_COUNT },
+      resultOffset: { initialValue: 0 },
+      ...
+```

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ export default connect(MyStripesComponent, 'moduleName');
 * A complete worked example of a connected component for editing patrons
 is explained in
 [A component example: the **PatronEdit** component](https://github.com/folio-org/stripes-core/blob/master/doc/component-example.md).
+* New features and migration paths for modules to opt-in to them are explained in [Migration Paths](MIGRATIONPATHS.md)
 
 ## Additional information
 

--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -697,11 +697,12 @@ export default class RESTResource {
                 url: response.url,
                 headers: response.headers,
                 httpStatus: response.status,
+                offset: resultOffset,
                 other: records ? _.omit(json, records) : {},
               };
               if (meta.other) meta.other.totalRecords = extractTotal(json);
               const data = (records ? json[records] : json);
-              dispatch(this.actions.accFetchSuccess(meta, data));
+              dispatch(this.actions.offsetFetchSuccess(meta, data));
             });
           }
         }).catch((err) => {

--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -659,9 +659,9 @@ export default class RESTResource {
 
               if (meta.other) meta.other.totalRecords = total;
               if (reqd && total && total > perPage && reqd >= perPage) {
-                if (options.resultOffset >= 0) {
-                  dispatch(this.fetchPage(options, total));
-                } else {
+                if (options.resultOffset >= 0) { // fetch one page by offset
+                  dispatch(this.fetchPageByOffset(options, total));
+                } else { // fetch all pages by total count
                   dispatch(this.fetchMore(options, total, data, meta));
                 }
               } else {
@@ -678,7 +678,8 @@ export default class RESTResource {
     };
   }
 
-  fetchPage = (options, total) => {
+  // Fetches a single page by offset adding it to the existing result list in redux
+  fetchPageByOffset = (options, total) => {
     const { headers, records, resultOffset, offsetParam } = options;
     const reqd = Math.min(resultOffset, total);
     return (dispatch) => {
@@ -711,6 +712,8 @@ export default class RESTResource {
     };
   }
 
+  // Fetches all pages until total records requested is reached
+  // overwriting the previously stored result list in redux
   fetchMore = (options, total, firstData, firstMeta) => {
     const { headers, records, recordsRequired,
       perRequest: limit, offsetParam } = options;

--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -660,10 +660,10 @@ export default class RESTResource {
               };
 
               if (meta.other) meta.other.totalRecords = total;
-              if (reqd && total && total > perPage && reqd > perPage) {
+              if (reqd && total && total > perPage) {
                 if (options.resultOffset) {
                   dispatch(this.fetchPage(options, total, data, meta));
-                } else {
+                } else if (reqd > perPage) {
                   dispatch(this.fetchMore(options, total, data, meta));
                 }
               } else {

--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -192,9 +192,7 @@ export function substitute(original, props, state, module, logger, dataKey) {
     throw new Error(`Invalid type passed to RESTResource.substitute(): ${typeof original} (${original})`);
   }
 
-  logger.log('substitute', `substitute(${
-    (typeof original === 'function') ? '<FUNCTION>' : original
-    }) -> ${result}, satisfied=${result !== null}`);
+  logger.log('substitute', `substitute(${(typeof original === 'function') ? '<FUNCTION>' : original}) -> ${result}, satisfied=${result !== null}`);
 
   return result;
 }
@@ -613,7 +611,7 @@ export default class RESTResource {
       }
 
       const { headers, records, resourceShouldRefresh } = options;
-      let requestIndex = options.resultOffset >= 0 ? options.resultOffset : options.recordsRequired;
+      const requestIndex = options.resultOffset >= 0 ? options.resultOffset : options.recordsRequired;
       // Check for existence of resourceShouldRefresh
       if (_.isUndefined(resourceShouldRefresh)) {
         // Maintain backward compatability if undefined maintin code
@@ -662,7 +660,7 @@ export default class RESTResource {
               if (meta.other) meta.other.totalRecords = total;
               if (reqd && total && total > perPage && reqd >= perPage) {
                 if (options.resultOffset >= 0) {
-                  dispatch(this.fetchPage(options, total, data, meta));
+                  dispatch(this.fetchPage(options, total));
                 } else {
                   dispatch(this.fetchMore(options, total, data, meta));
                 }
@@ -680,19 +678,14 @@ export default class RESTResource {
     };
   }
 
-  fetchPage = (options, total, firstData, firstMeta) => {
-    const { headers, records, resultOffset,
-      perRequest: limit, offsetParam } = options;
+  fetchPage = (options, total) => {
+    const { headers, records, resultOffset, offsetParam } = options;
     const reqd = Math.min(resultOffset, total);
     return (dispatch) => {
-      //dispatch(this.actions.pagingStart());
-      //dispatch(this.actions.pageStart(firstMeta.url));
-      //for (let offset = limit; offset < reqd; offset += limit) {
       const newOptions = {};
       newOptions.params = {};
       newOptions.params[offsetParam] = reqd;
       const url = urlFromOptions(_.merge({}, options, newOptions));
-      //dispatch(this.actions.pageStart(url));
       fetch(url, { headers })
         .then((response) => {
           if (response.status >= 400) {
@@ -715,8 +708,6 @@ export default class RESTResource {
             message: `Unexpected fetch error ${err}`,
           }));
         });
-      //}
-      //dispatch(this.actions.pageSuccess(firstMeta, firstData));
     };
   }
 

--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -278,7 +278,7 @@ export default class RESTResource {
       // resultOffset
       if (typeof options.resultOffset === 'string' || typeof options.resultOffset === 'function') {
         const tmplResultOffset = Number.parseInt(substitute(options.resultOffset, props, state, this.module, this.logger, this.dataKey), 10);
-        if (tmplResultOffset > 0) {
+        if (tmplResultOffset >= 0) {
           options.resultOffset = tmplResultOffset;
         } else {
           return null;
@@ -613,7 +613,7 @@ export default class RESTResource {
       }
 
       const { headers, records, resourceShouldRefresh } = options;
-      let requestIndex = options.resultOffset || options.recordsRequired
+      let requestIndex = options.resultOffset >= 0 ? options.resultOffset : options.recordsRequired;
       // Check for existence of resourceShouldRefresh
       if (_.isUndefined(resourceShouldRefresh)) {
         // Maintain backward compatability if undefined maintin code
@@ -660,10 +660,10 @@ export default class RESTResource {
               };
 
               if (meta.other) meta.other.totalRecords = total;
-              if (reqd && total && total > perPage) {
-                if (options.resultOffset) {
+              if (reqd && total && total > perPage && reqd >= perPage) {
+                if (options.resultOffset >= 0) {
                   dispatch(this.fetchPage(options, total, data, meta));
-                } else if (reqd > perPage) {
+                } else {
                   dispatch(this.fetchMore(options, total, data, meta));
                 }
               } else {

--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -14,7 +14,7 @@ const defaultDefaults = { pk: 'id', clientGeneratePk: true, fetch: true, clear: 
 
 function extractTotal(json) {
   if (json.resultInfo !== undefined &&
-      json.resultInfo.totalRecords !== undefined) {
+    json.resultInfo.totalRecords !== undefined) {
     return json.resultInfo.totalRecords;
   } else if (json.totalRecords !== undefined) {
     return json.totalRecords;
@@ -194,7 +194,7 @@ export function substitute(original, props, state, module, logger, dataKey) {
 
   logger.log('substitute', `substitute(${
     (typeof original === 'function') ? '<FUNCTION>' : original
-  }) -> ${result}, satisfied=${result !== null}`);
+    }) -> ${result}, satisfied=${result !== null}`);
 
   return result;
 }
@@ -395,7 +395,7 @@ export default class RESTResource {
     if (opt.accumulate === true
       || opt.fetch === false
       || (typeof opt.fetch === 'function'
-          && opt.fetch(props) !== true)
+        && opt.fetch(props) !== true)
     ) return;
     if (props.dataKey === this.dataKey) dispatch(this.fetchAction(props));
     this.dispatch = dispatch;
@@ -650,7 +650,7 @@ export default class RESTResource {
 
               if (meta.other) meta.other.totalRecords = total;
               if (reqd && total && total > perPage && reqd > perPage) {
-                dispatch(this.fetchMore(options, total, data, meta));
+                dispatch(this.fetchPage(options, total, data, meta));
               } else {
                 dispatch(this.actions.fetchSuccess(meta, data));
                 // restart paging if there is any, otherwise any cached pages will
@@ -662,6 +662,46 @@ export default class RESTResource {
         }).catch((reason) => {
           dispatch(this.actions.fetchError({ message: reason.message }));
         });
+    };
+  }
+
+  fetchPage = (options, total, firstData, firstMeta) => {
+    const { headers, records, recordsRequired,
+      perRequest: limit, offsetParam } = options;
+    const reqd = Math.min(recordsRequired, total);
+    return (dispatch) => {
+      //dispatch(this.actions.pagingStart());
+      //dispatch(this.actions.pageStart(firstMeta.url));
+      //for (let offset = limit; offset < reqd; offset += limit) {
+      const newOptions = {};
+      newOptions.params = {};
+      newOptions.params[offsetParam] = reqd;
+      const url = urlFromOptions(_.merge({}, options, newOptions));
+      //dispatch(this.actions.pageStart(url));
+      fetch(url, { headers })
+        .then((response) => {
+          if (response.status >= 400) {
+            dispatch(this.fetchHTTPError(response));
+          } else {
+            response.json().then((json) => {
+              const meta = {
+                url: response.url,
+                headers: response.headers,
+                httpStatus: response.status,
+                other: records ? _.omit(json, records) : {},
+              };
+              if (meta.other) meta.other.totalRecords = extractTotal(json);
+              const data = (records ? json[records] : json);
+              dispatch(this.actions.accFetchSuccess(meta, data));
+            });
+          }
+        }).catch((err) => {
+          dispatch(this.actions.fetchError({
+            message: `Unexpected fetch error ${err}`,
+          }));
+        });
+      //}
+      //dispatch(this.actions.pageSuccess(firstMeta, firstData));
     };
   }
 

--- a/RESTResource/actionCreatorsFor.js
+++ b/RESTResource/actionCreatorsFor.js
@@ -40,6 +40,8 @@ export default function actionCreatorsFor(resource) {
 
     accFetchSuccess: passMetaPayload('ACC_FETCH_SUCCESS'),
 
+    offsetFetchSuccess: passMetaPayload('OFFSET_FETCH_SUCCESS'),
+
     fetchError: passPayload('FETCH_ERROR'),
 
     fetchAbort: passPayload('FETCH_ABORT'),

--- a/RESTResource/reducer.js
+++ b/RESTResource/reducer.js
@@ -47,7 +47,7 @@ export default function (state = initialResourceState, action) {
       });
     }
     case '@@stripes-connect/OFFSET_FETCH_SUCCESS': {
-      let records = [...state.records];
+      const records = [...state.records];
       if (Array.isArray(action.payload)) records.splice(action.meta.offset, 0, ...action.payload);
       else records.splice(action.meta.offset, 0, _.clone(action.payload));
       return Object.assign({}, state, {

--- a/RESTResource/reducer.js
+++ b/RESTResource/reducer.js
@@ -46,6 +46,19 @@ export default function (state = initialResourceState, action) {
         ...action.meta,
       });
     }
+    case '@@stripes-connect/OFFSET_FETCH_SUCCESS': {
+      let records = [...state.records];
+      if (Array.isArray(action.payload)) records.splice(action.meta.offset, 0, ...action.payload);
+      else records.splice(action.meta.offset, 0, _.clone(action.payload));
+      return Object.assign({}, state, {
+        hasLoaded: true,
+        loadedAt: new Date(),
+        isPending: false,
+        failed: false,
+        records,
+        ...action.meta,
+      });
+    }
     case '@@stripes-connect/RESET': {
       return initialResourceState;
     }

--- a/test/integration.js
+++ b/test/integration.js
@@ -95,6 +95,20 @@ Paged.manifest = { pagedResource: {
   perRequest: 5,
 } };
 
+class PagedOffset extends Component { // eslint-disable-line react/no-multi-comp
+  render() {
+    return <div id="somediv" />;
+  }
+}
+PagedOffset.manifest = { pagedResource: {
+  type: 'okapi',
+  path: 'turnip',
+  params: { q: 'dinner', offset: '5' },
+  records: 'records',
+  offsetParam: 'offset',
+  perRequest: 5,
+} };
+
 class CompWithPerms extends Component { // eslint-disable-line react/no-multi-comp
   render() {
     return <div id="somediv" />;
@@ -295,6 +309,27 @@ describe('connect()', () => {
 
     setTimeout(() => {
       inst.find(Paged).instance().props.resources.pagedResource.records.length.should.equal(14);
+      fetchMock.restore();
+      done();
+    }, 40);
+  });
+
+  it('should only make 1 request for a paged offset resource', (done) => {
+    fetchMock
+      .getOnce('http://localhost/turnip?limit=5&offset=5&q=dinner',
+        { records:[{ 'id':'58e55786065039ceb9acb0e2', 'name':'Lucas' }, { 'id':'58e55786e2106a216fdb5629', 'name':'Kirkland' }, { 'id':'58e55786819013f1e810d28e', 'name':'Clarke' }, { 'id':'58e55786e51f01bc81b11f32', 'name':'Acevedo' }, { 'id':'58e55786791c37697eec2bc2', 'name':'Earnestine' }], total_records:5 },
+        { headers: { 'Content-Type': 'application/json' } })
+        .catch(503);
+
+    const store = createStore((state) => state,
+      { okapi: { url: 'http://localhost', tenant: 'tenantid' } },
+      applyMiddleware(thunk));
+
+    const Connected = connect(PagedOffset, 'testoffset', mockedEpics, defaultLogger);
+    const inst = mount(<Root store={store} component={Connected} />);
+
+    setTimeout(() => {
+      inst.find(PagedOffset).instance().props.resources.pagedResource.records.length.should.equal(5);
       fetchMock.restore();
       done();
     }, 40);

--- a/test/integration.js
+++ b/test/integration.js
@@ -319,7 +319,7 @@ describe('connect()', () => {
       .getOnce('http://localhost/turnip?limit=5&offset=5&q=dinner',
         { records:[{ 'id':'58e55786065039ceb9acb0e2', 'name':'Lucas' }, { 'id':'58e55786e2106a216fdb5629', 'name':'Kirkland' }, { 'id':'58e55786819013f1e810d28e', 'name':'Clarke' }, { 'id':'58e55786e51f01bc81b11f32', 'name':'Acevedo' }, { 'id':'58e55786791c37697eec2bc2', 'name':'Earnestine' }], total_records:5 },
         { headers: { 'Content-Type': 'application/json' } })
-        .catch(503);
+      .catch(503);
 
     const store = createStore((state) => state,
       { okapi: { url: 'http://localhost', tenant: 'tenantid' } },

--- a/test/reducer.js
+++ b/test/reducer.js
@@ -16,23 +16,23 @@ const initialResourceState = {
 };
 
 const action = {
-	type: '@@stripes-connect/OFFSET_FETCH_SUCCESS',
-	payload: [],
-	meta: {
-		offset: 0
-	}
+  type: '@@stripes-connect/OFFSET_FETCH_SUCCESS',
+  payload: [],
+  meta: {
+    offset: 0
+  }
 };
 
 const reduce = reducer.bind({});
 
 describe('reduce()', () => {
-	it('returns empty array when nothing is passed in', () => {
-		reduce(initialResourceState, action).records
-			.should.eql([]);
-	});
+  it('returns empty array when nothing is passed in', () => {
+    reduce(initialResourceState, action).records
+      .should.eql([]);
+  });
 
-	it('adds new records to beginning when offset of 0 is used', () => {
-		reduce(initialResourceState, Object.assign({}, action, { payload: [1, 2, 3] })).records
-			.should.eql([1, 2, 3]);
-	});
+  it('adds new records to beginning when offset of 0 is used', () => {
+    reduce(initialResourceState, Object.assign({}, action, { payload: [1, 2, 3] })).records
+      .should.eql([1, 2, 3]);
+  });
 });

--- a/test/reducer.js
+++ b/test/reducer.js
@@ -1,0 +1,38 @@
+import { should } from 'chai';
+import { describe, it } from 'mocha';
+
+import reducer from '../RESTResource/reducer';
+
+should();
+
+const initialResourceState = {
+  hasLoaded: false,
+  isPending: false,
+  failed: false,
+  records: [],
+  successfulMutations: [],
+  failedMutations: [],
+  pendingMutations: [],
+};
+
+const action = {
+	type: '@@stripes-connect/OFFSET_FETCH_SUCCESS',
+	payload: [],
+	meta: {
+		offset: 0
+	}
+};
+
+const reduce = reducer.bind({});
+
+describe('reduce()', () => {
+	it('returns empty array when nothing is passed in', () => {
+		reduce(initialResourceState, action).records
+			.should.eql([]);
+	});
+
+	it('adds new records to beginning when offset of 0 is used', () => {
+		reduce(initialResourceState, Object.assign({}, action, { payload: [1, 2, 3] })).records
+			.should.eql([1, 2, 3]);
+	});
+});


### PR DESCRIPTION
Provide an opt-in path for requesting pages one-at-a-time by offset, i.e. by clicking a "Load more" button, as an alternative to infinite scroll. 

It's a cherry-pick of the commits in #117 onto a patch branch in order to make that feature, and that feature alone, available as a patch to the [2019-q4 stripes release](https://github.com/folio-org/stripes/releases/tag/v2.12.1). 