### PR TITLE
Added originatingActionType to REFRESH action.meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-connect
 
+## 5.6.0 IN PROGRESS
+
+* Added `originatingActionType` to `REFRESH` action `meta` objects.
+
 ## [5.5.0](https://github.com/folio-org/stripes-connect/tree/v5.5.0) (2020-03-03)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v5.4.4...v5.5.0)
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -170,7 +170,10 @@ via limitParam/offsetParam.
   of permissions required for the given resource to be fetched.
 
 * `shouldRefresh`: An optional function which can be used to indicate if the
-given resource should be refreshed when another resource is mutated.
+given resource should be refreshed when another resource is mutated. The function is passed
+the `resource` itself and the refresh `action`. The `action` contains the standard `type`, `meta`,
+etc fields. The `action.meta` additionally contains an `originatingActionType` string
+that contains the action type that resulted in this refresh request. Eg, `@@stripes-connect/DELETE_SUCCESS`.
 
 * `resultOffset`: A number, interpolated string, or function indicating what offset
   into the results list should be fetched. This is an optional workflow that allows

--- a/epics/mutationEpics.js
+++ b/epics/mutationEpics.js
@@ -15,7 +15,13 @@ export default function mutationEpics(resource) {
       path = path && path.replace(/[\/].*$/g, '');  // eslint-disable-line no-useless-escape
 
       const name = resource.name;
-      const meta = Object.assign({}, action.meta, { path, name });
+      const meta = {
+        ...action.meta,
+        originatingActionType: action.type,
+        path,
+        name,
+      };
+
       return { ...action, meta, type: 'REFRESH' };
     }));
 }


### PR DESCRIPTION
This lets us better scope the `shouldRefresh` for our resources. 

For example, if we have a resource that we fetch/update/refresh, but also enable the deletion of, the delete will trigger a REFRESH action on that resource that will throw an error (likely a 404). We can sometimes solve this by passing `{ silent: true }`, but then other resources that _should_ refresh based on the deletion aren't refreshed.

Now we can write something like this:
```
      shouldRefresh: (resource, action) => {
        if (resource.name !== 'agreement') return true;
        return !action.meta.originatingActionType?.includes('DELETE');
      },
```

[Slack thread that started this was this one.](https://folio-project.slack.com/archives/C210UCHQ9/p1584993996003600)