### PR TITLE
UIU-1295 correctly receive opts in createAction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-connect
 
+## 5.5.1 (IN PROGRESS)
+
+* Correctly receive `opts` in `createAction`. Refs UIU-1295.
+
 ## [5.5.0](https://github.com/folio-org/stripes-connect/tree/v5.5.0) (2020-03-03)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v5.4.4...v5.5.0)
 

--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -497,7 +497,7 @@ export default class RESTResource {
     };
   }
 
-  createAction = (record, props) => (dispatch, getState, opts) => {
+  createAction = (record, props, opts) => (dispatch, getState) => {
     const options = this.verbOptions('POST', getState(), { clientGeneratePk: true, ...props });
     const { pk, clientGeneratePk, headers } = options;
     const url = urlFromOptions(options);


### PR DESCRIPTION
Correctly receive `opts` in `createAction`.

Refs [UIU-1295](https://issues.folio.org/browse/UIU-1295)