### PR TITLE
bump package patch in concert with latest release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-connect",
-  "version": "5.5.0",
+  "version": "5.5.1",
   "description": "Declarative REST data access for React components",
   "repository": "folio-org/stripes-connect",
   "sideEffects": [


### PR DESCRIPTION
The master branch version must be >= the latest released version in
order for clones in a workspace to be accepted as fulfilling the current
stripes dep on `~5.5.1`.