### PR TITLE
throw better errors

### DIFF
--- a/connect.js
+++ b/connect.js
@@ -219,7 +219,9 @@ defaultLogger.log = (cat, ...args) => {
 export const connect = (Component, module, epics, loggerArg, options) => {
   const logger = loggerArg || defaultLogger;
   if (typeof Component === 'undefined') {
-    throw Error(`connect() called on an undefined component from ${module}`);
+    throw Error(`connect() called on an undefined component from ${module}.
+This generally tends to be the case when you imported a component from the wrong place, so triple-check your paths and whether something is a named or default export!
+Also, the component file may have failed to parse correctly. Check the browser console logs to see if this may be the case.`);
   }
 
   if (typeof Component.manifest === 'undefined') {

--- a/connect.js
+++ b/connect.js
@@ -218,6 +218,10 @@ defaultLogger.log = (cat, ...args) => {
 
 export const connect = (Component, module, epics, loggerArg, options) => {
   const logger = loggerArg || defaultLogger;
+  if (typeof Component === 'undefined') {
+    throw Error(`connect() called on an undefined component from ${module}`);
+  }
+
   if (typeof Component.manifest === 'undefined') {
     logger.log('connect-no', `not connecting <${Component.name}> for '${module}': no manifest`);
     return Component;


### PR DESCRIPTION
Currently we just blaze ahead trying to index into Component. When the Component is undefined, this is a problem. Let's give better info about why a component may be undefined.