### PR TITLE
STCON-102: Restart paging correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 5.6.0 IN PROGRESS
 
 * Added `originatingActionType` to `REFRESH` action `meta` objects.
+* Restart paging correctly. STCON-102.
 
 ## [5.5.0](https://github.com/folio-org/stripes-connect/tree/v5.5.0) (2020-03-03)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v5.4.4...v5.5.0)

--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -731,7 +731,7 @@ export default class RESTResource {
                 dispatch(this.actions.fetchSuccess(meta, data));
                 // restart paging if there is any, otherwise any cached pages will
                 // populate the UI the next time the connected component mounts.
-                dispatch(this.actions.pageStart());
+                dispatch(this.actions.pagingStart());
               }
             });
           }


### PR DESCRIPTION
https://issues.folio.org/browse/STCON-102

It looks like we were using a wrong action for restarting pagination which caused part of the redux store to leak:

![pagination-leak](https://user-images.githubusercontent.com/63545/82071775-8fd31600-96a4-11ea-9eba-949dafd82b57.png)

The easiest way to reproduce it is to go to ui-users and keep switching between users.

@ryandberger I'm not sure if the `[]` defined in:

https://github.com/folio-org/stripes-connect/blob/master/RESTResource/RESTResource.js#L362
 
is fine here (things seem to work as expected) or if we need to use the single entry defined in:

https://github.com/folio-org/stripes-connect/blob/master/RESTResource/RESTResource.js#L366-L371

BTW here is how things look like after this change:

![redux_paging](https://user-images.githubusercontent.com/63545/82072329-90b87780-96a5-11ea-8179-af78e48ea0b7.png)
