### PR TITLE
Clear resources array on unmount

### DIFF
--- a/connect.js
+++ b/connect.js
@@ -30,10 +30,10 @@ function arePropsEqual(props, prevProps) {
 }
 
 const wrap = (Wrapped, module, epics, logger, options = {}) => {
-  const resources = [];
+  let resources = [];
   const dataKey = options.dataKey;
 
-  _.map(Wrapped.manifest, (query, name) => {
+  _.forOwn(Wrapped.manifest, (query, name) => {
     const resource = new types[query.type || defaultType](name, query, module, logger, query.dataKey || dataKey);
     resources.push(resource);
     if (query.type === 'okapi') {
@@ -138,6 +138,7 @@ const wrap = (Wrapped, module, epics, logger, options = {}) => {
           }
         }
       });
+      resources = [];
     }
 
     componentShouldRefreshRemote(nextProps) {


### PR DESCRIPTION
Thanks to @zburke for digging into it deeper and tracking down this leak:

![resources_leak](https://user-images.githubusercontent.com/63545/82072895-65825800-96a6-11ea-9571-d875951ab26e.png)

This PR clears resources array on unmount.