### PR TITLE
Introduce resource registry

### DIFF
--- a/ResourceRegistry.js
+++ b/ResourceRegistry.js
@@ -1,0 +1,29 @@
+import forOwn from 'lodash/forOwn';
+
+export default class ResourceRegistry {
+  constructor() {
+    this.registry = {};
+  }
+
+  register(module, resource) {
+    if (!this.registry[module]) {
+      this.registry[module] = {};
+    }
+
+    this.registry[module][resource.name] = resource;
+  }
+
+  getResources(module, manifest) {
+    const resources = [];
+
+    forOwn(manifest, (_, name) => {
+      resources.push(this.registry[module][name]);
+    });
+
+    return resources;
+  }
+
+  clear() {
+    this.registry = {};
+  }
+}

--- a/ResourceRegistry.js
+++ b/ResourceRegistry.js
@@ -1,29 +1,17 @@
-import forOwn from 'lodash/forOwn';
-
 export default class ResourceRegistry {
   constructor() {
-    this.registry = {};
+    this.list = [];
   }
 
-  register(module, resource) {
-    if (!this.registry[module]) {
-      this.registry[module] = {};
-    }
-
-    this.registry[module][resource.name] = resource;
-  }
-
-  getResources(module, manifest) {
-    const resources = [];
-
-    forOwn(manifest, (_, name) => {
-      resources.push(this.registry[module][name]);
-    });
-
-    return resources;
+  add(array) {
+    this.list.push(array);
   }
 
   clear() {
-    this.registry = {};
+    for (let i = 0, l = this.list.length; i < l; i++) {
+      this.list[i].splice(0, this.list[i].length);
+      this.list[i] = null;
+    }
+    this.list = [];
   }
 }

--- a/connect.js
+++ b/connect.js
@@ -35,7 +35,7 @@ const wrap = (Wrapped, module, epics, logger, options = {}) => {
   const dataKey = options.dataKey;
   const { manifest } = Wrapped;
 
-  _.map(manifest, (query, name) => {
+  _.forOwn(manifest, (query, name) => {
     const resource = new types[query.type || defaultType](name, query, module, logger, query.dataKey || dataKey);
     resourceRegistry.register(module, resource);
     if (query.type === 'okapi') {


### PR DESCRIPTION
In order to be able to clean resources between tests (during full app unmount) we need to be able to have access to the currently registered resources. This PR introduced a `ResourceRegistry` to keep track of the registered resources with the ability to reset them.

The current implementation of the resource registry comes from @zburke which simplified things a lot!