### PR TITLE
STCON-104: Add ability to cancel pending requests

### DIFF
--- a/OkapiResource.js
+++ b/OkapiResource.js
@@ -5,7 +5,7 @@ const defaults = {
   clientGeneratePk: true,
   fetch: true,
   clear: true,
-  abortOnUnmount: false,
+  abortable: false,
   limitParam: 'limit',
   offsetParam: 'offset',
   headers: {

--- a/OkapiResource.js
+++ b/OkapiResource.js
@@ -5,7 +5,7 @@ const defaults = {
   clientGeneratePk: true,
   fetch: true,
   clear: true,
-  abortable: true,
+  abortOnUnmount: false,
   limitParam: 'limit',
   offsetParam: 'offset',
   headers: {

--- a/OkapiResource.js
+++ b/OkapiResource.js
@@ -6,6 +6,7 @@ const defaults = {
   fetch: true,
   clear: true,
   abortable: false,
+  abortOnUnmount: false,
   limitParam: 'limit',
   offsetParam: 'offset',
   headers: {

--- a/OkapiResource.js
+++ b/OkapiResource.js
@@ -5,6 +5,7 @@ const defaults = {
   clientGeneratePk: true,
   fetch: true,
   clear: true,
+  abortable: true,
   limitParam: 'limit',
   offsetParam: 'offset',
   headers: {

--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -5,7 +5,14 @@ import queryString from 'query-string';
 import actionCreatorsFor from './actionCreatorsFor';
 import reducer from './reducer';
 
-const defaultDefaults = { pk: 'id', clientGeneratePk: true, fetch: true, clear: true, abortable: false };
+const defaultDefaults = {
+  pk: 'id',
+  clientGeneratePk: true,
+  fetch: true,
+  clear: true,
+  abortable: false,
+  abortOnUnmount: false,
+};
 
 /**
  * extractTotal
@@ -485,7 +492,7 @@ export default class RESTResource {
   }
 
   addAbortController(key, options) {
-    if (!options.abortable) {
+    if (!options.abortable && !options.abortOnUnmount) {
       return null;
     }
 
@@ -495,6 +502,14 @@ export default class RESTResource {
     this.abortControllers[key] = ctrl;
 
     return signal;
+  }
+
+  cancelRequestsOnUnmout() {
+    const { abortOnUnmount } = this.optionsTemplate;
+
+    if (abortOnUnmount) {
+      this.cancelRequests();
+    }
   }
 
   cancelRequests() {

--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -6,7 +6,7 @@ import queryString from 'query-string';
 import actionCreatorsFor from './actionCreatorsFor';
 import reducer from './reducer';
 
-const defaultDefaults = { pk: 'id', clientGeneratePk: true, fetch: true, clear: true };
+const defaultDefaults = { pk: 'id', clientGeneratePk: true, fetch: true, clear: true, abortable: true };
 
 /**
  * extractTotal
@@ -486,8 +486,10 @@ export default class RESTResource {
   }
 
   cancelRequests() {
-    Object.values(this.abortControllers).forEach(ctrl => ctrl.abort());
-    this.abortControllers = {};
+    if (this.optionsTemplate.abortable) {
+      Object.values(this.abortControllers).forEach(ctrl => ctrl.abort());
+      this.abortControllers = {};
+    }
   }
 
   hasMissingPerms(state, perms) {

--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -748,7 +748,7 @@ export default class RESTResource {
               }
             });
           }
-        }).catch((reason) => this.fetchAbortOrError(reason, dispatch));
+        }).catch((reason) => this.handleFetchOrAbortError(reason, dispatch));
     };
   }
 
@@ -783,7 +783,7 @@ export default class RESTResource {
               dispatch(this.actions.offsetFetchSuccess(meta, data));
             });
           }
-        }).catch((reason) => this.fetchAbortOrError(reason, dispatch));
+        }).catch((reason) => this.handleFetchOrAbortError(reason, dispatch));
     };
   }
 
@@ -842,7 +842,7 @@ export default class RESTResource {
                 dispatch(this.actions.pageSuccess(meta, data));
               });
             }
-          }).catch((reason) => this.fetchAbortOrError(reason, dispatch));
+          }).catch((reason) => this.handleFetchOrAbortError(reason, dispatch));
       }
       dispatch(this.actions.pageSuccess(firstMeta, firstData));
     };
@@ -894,13 +894,13 @@ export default class RESTResource {
             return data;
           }));
 
-      beforeCatch.catch((reason) => this.fetchAbortOrError(reason, dispatch));
+      beforeCatch.catch((reason) => this.handleFetchOrAbortError(reason, dispatch));
 
       return beforeCatch;
     };
   }
 
-  fetchAbortOrError = (reason, dispatch) => {
+  handleFetchOrAbortError = (reason, dispatch) => {
     const { name, message } = reason;
 
     if (name === 'AbortError') {

--- a/connect.js
+++ b/connect.js
@@ -140,7 +140,7 @@ const wrap = (Wrapped, module, epics, logger, options = {}) => {
           }
 
           if (!resource.isVisible()) {
-            resource.cancelRequests();
+            resource.cancelRequestsOnUnmout();
           }
         }
       });

--- a/connect.js
+++ b/connect.js
@@ -138,6 +138,10 @@ const wrap = (Wrapped, module, epics, logger, options = {}) => {
           if (resource.shouldReset()) {
             resource.reset();
           }
+
+          if (!resource.isVisible()) {
+            resource.cancelRequests();
+          }
         }
       });
     }

--- a/doc/api.md
+++ b/doc/api.md
@@ -169,7 +169,7 @@ via limitParam/offsetParam.
   resource, which allows it to be used in code that expects to receive a
   promise. Default: `false`.
 
-* `abortOnUnmount`: A boolean which can be used to control if the given pending resource
+* `abortable`: A boolean which can be used to control if the given pending resource
   should be aborted during component unmount. Default `true`.
 
 * `permissionsRequired`: A string (or an array of strings) indicating the list

--- a/doc/api.md
+++ b/doc/api.md
@@ -169,6 +169,9 @@ via limitParam/offsetParam.
   resource, which allows it to be used in code that expects to receive a
   promise. Default: `false`.
 
+* `abortable`: A boolean which can be used to control if the given pending resource
+  should be aborted during component unmount. Default `true`.
+
 * `permissionsRequired`: A string (or an array of strings) indicating the list
   of permissions required for the given resource to be fetched.
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -169,7 +169,7 @@ via limitParam/offsetParam.
   resource, which allows it to be used in code that expects to receive a
   promise. Default: `false`.
 
-* `abortable`: A boolean which can be used to control if the given pending resource
+* `abortOnUnmount`: A boolean which can be used to control if the given pending resource
   should be aborted during component unmount. Default `true`.
 
 * `permissionsRequired`: A string (or an array of strings) indicating the list

--- a/doc/api.md
+++ b/doc/api.md
@@ -169,8 +169,11 @@ via limitParam/offsetParam.
   resource, which allows it to be used in code that expects to receive a
   promise. Default: `false`.
 
-* `abortable`: A boolean which can be used to control if the given pending resource
-  should be aborted during component unmount. Default `true`.
+* `abortable`: A boolean indicating whether given resource can be
+  aborted manually by calling `resource.cancel()`. Default `false`.
+
+* `abortOnUnmount`: A boolean which can be used to control if the given pending
+  resource should be aborted during component unmount. Default `false`.
 
 * `permissionsRequired`: A string (or an array of strings) indicating the list
   of permissions required for the given resource to be fetched.

--- a/package.json
+++ b/package.json
@@ -47,10 +47,10 @@
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
     "redux-thunk": "^2.1.0",
-    "regenerator-runtime": "^0.13.3"
+    "regenerator-runtime": "^0.13.3",
+    "abort-controller": "^3.0.0"
   },
   "dependencies": {
-    "abort-controller": "^3.0.0",
     "lodash": "^4.17.11",
     "prop-types": "^15.5.10",
     "query-string": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
     "eslint": "^6.2.1",
-    "fetch-mock": "5.11.2",
+    "fetch-mock": "9.10.1",
     "jsdom": "^12.1.0",
     "jsdom-global": "^3.0.2",
     "mocha": "^6.1.3",
@@ -49,6 +49,7 @@
     "regenerator-runtime": "^0.13.3"
   },
   "dependencies": {
+    "abort-controller": "^3.0.0",
     "lodash": "^4.17.11",
     "prop-types": "^15.5.10",
     "query-string": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "jsdom": "^12.1.0",
     "jsdom-global": "^3.0.2",
     "mocha": "^6.1.3",
+    "node-fetch": "^2.6.1",
     "react": "^16.3.0",
     "react-dom": "^16.3.0",
     "redux-thunk": "^2.1.0",

--- a/test/integration.js
+++ b/test/integration.js
@@ -298,6 +298,7 @@ describe('connect()', () => {
 
     setTimeout(() => {
       inst.find(Remote).instance().props.resources.remoteResource.records[0].someprop.should.equal('someval');
+      inst.find(Remote).instance().props.resources.remoteResource.successfulMutations[0].record.someprop.should.equal('newer');
       fetchMock.restore();
       done();
     }, 10);

--- a/test/integration.js
+++ b/test/integration.js
@@ -98,7 +98,7 @@ Unmounted.manifest = {
   unmounted: {
     type: 'okapi',
     path: 'unmounted',
-    abortable: true,
+    abortOnUnmount: true,
   },
 };
 

--- a/test/integration.js
+++ b/test/integration.js
@@ -1,4 +1,5 @@
 import 'jsdom-global/register';
+import AbortController from 'abort-controller';
 import chai from 'chai';
 import { describe, it } from 'mocha';
 import Enzyme, { mount } from 'enzyme';
@@ -14,6 +15,7 @@ import ConnectContext from '../ConnectContext';
 
 import { connect } from '../connect';
 
+global.window.AbortController = AbortController;
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -87,7 +89,7 @@ Accumulated.manifest = {
     type: 'okapi',
     path: 'accumulated',
     accumulate: true,
-    abortOnUnmount: true,
+    abortable: true,
   },
 };
 
@@ -96,7 +98,7 @@ Unmounted.manifest = {
   unmounted: {
     type: 'okapi',
     path: 'unmounted',
-    abortOnUnmount: true,
+    abortable: true,
   },
 };
 

--- a/test/integration.js
+++ b/test/integration.js
@@ -87,6 +87,7 @@ Accumulated.manifest = {
     type: 'okapi',
     path: 'accumulated',
     accumulate: true,
+    abortOnUnmount: true,
   },
 };
 
@@ -95,6 +96,7 @@ Unmounted.manifest = {
   unmounted: {
     type: 'okapi',
     path: 'unmounted',
+    abortOnUnmount: true,
   },
 };
 

--- a/test/integration.js
+++ b/test/integration.js
@@ -36,11 +36,11 @@ class Root extends Component {
   }
 
   render() {
-    const { component:ToTest } = this.props;
+    const { component: ToTest, hideConnected } = this.props;
     return (
       <Provider store={this.props.store}>
         <ConnectContext.Provider value={{ addReducer: this.addReducer, addEpic: this.addEpic, store: this.props.store }}>
-          <ToTest fooProp="foo" {...this.props} />
+          {!hideConnected && <ToTest fooProp="foo" {...this.props} />}
         </ConnectContext.Provider>
       </Provider>
     );
@@ -80,6 +80,24 @@ Remote.manifest = { remoteResource: {
   type: 'okapi',
   path: 'turnip',
 } };
+
+const Accumulated = () => (<div id="somediv" />);
+Accumulated.manifest = {
+  accumulated: {
+    type: 'okapi',
+    path: 'accumulated',
+    accumulate: true,
+  },
+};
+
+const Unmounted = () => (<div id="somediv" />);
+Unmounted.manifest = {
+  unmounted: {
+    type: 'okapi',
+    path: 'unmounted',
+  },
+};
+
 
 class Paged extends Component { // eslint-disable-line react/no-multi-comp
   render() {
@@ -248,15 +266,15 @@ describe('connect()', () => {
         [{ id: 1, someprop: 'someval' }],
         { headers: { 'Content-Type': 'application/json' } })
       .put('http://localhost/turnip/1',
-        { id: 1, someprop: 'someval' },
-        { headers: { 'Content-Type': 'application/json' } })
+        { id: 1, someprop: 'new' },
+        { status: 200, headers: { 'Content-Type': 'application/json' } })
       .post('http://localhost/turnip',
-        { id: 1, someprop: 'someval' },
+        { id: 1, someprop: 'newer' },
         { headers: { 'Content-Type': 'application/json' } })
       .delete('http://localhost/turnip/1',
         { id: 1, someprop: 'someval' },
         { headers: { 'Content-Type': 'application/json' } })
-      .catch(503);
+      .catch({ status: 503 });
 
     const store = createStore((state) => state,
       { okapi: { url: 'http://localhost', tenant: 'tenantid' } },
@@ -265,7 +283,7 @@ describe('connect()', () => {
     const Connected = connect(Remote, 'test', mockedEpics, defaultLogger);
     const inst = mount(<Root store={store} component={Connected} />);
 
-    inst.find(Remote).props().mutator.remoteResource.PUT({ id:1, someprop:'new' })
+    inst.find(Remote).props().mutator.remoteResource.PUT({ id: 1, someprop: 'new' })
       .then(res => res.someprop.should.equal('new'));
     fetchMock.lastCall()[1].body.should.equal('{"id":1,"someprop":"new"}');
     fetchMock.lastCall()[1].headers['X-Okapi-Tenant'].should.equal('tenantid');
@@ -280,7 +298,6 @@ describe('connect()', () => {
 
     setTimeout(() => {
       inst.find(Remote).instance().props.resources.remoteResource.records[0].someprop.should.equal('someval');
-      inst.find(Remote).instance().props.resources.remoteResource.successfulMutations[0].record.someprop.should.equal('newer');
       fetchMock.restore();
       done();
     }, 10);
@@ -361,10 +378,10 @@ describe('connect()', () => {
   it('should fail appropriately', (done) => {
     fetchMock
       .get('http://localhost/turnep',
-        { status: 404 })
+        { status: 404, body: 'forbidden' })
       .post('http://localhost/turnep',
         { status: 403, body: 'You are forbidden because reasons.' })
-      .catch(503);
+      .catch({ status: 503 });
 
     const store = createStore((state) => state,
       { okapi: { url: 'http://localhost', tenant: 'tenantid' } },
@@ -374,8 +391,10 @@ describe('connect()', () => {
     const inst = mount(<Root store={store} component={Connected} />);
     inst.find(ErrorProne).props().mutator.errorProne.POST({ id:1, someprop:'new' })
       .catch(err => err.text().then(msg => msg.should.equal('You are forbidden because reasons.')));
+
     setTimeout(() => {
       const res = inst.find(ErrorProne).instance().props.resources.errorProne;
+
       res.isPending.should.equal(false);
       res.failed.httpStatus.should.equal(404);
       res.failedMutations[0].message.should.equal('You are forbidden because reasons.');
@@ -533,5 +552,52 @@ describe('connect()', () => {
       res.records[0].someprop.should.equal('otherval');
       done();
     }, 100);
+  });
+
+  it('should cancel request when connected component unmounts', (done) => {
+    fetchMock
+      .get('http://localhost/unmounted',
+        [{ id: 1 }],
+        { delay: 1000,
+          headers: { 'Content-Type': 'application/json' } });
+
+    const store = createStore((state) => state,
+      { okapi: { url: 'http://localhost', tenant: 'tenantid' } },
+      applyMiddleware(thunk));
+
+    const Connected = connect(Unmounted, 'test', mockedEpics, defaultLogger);
+    const inst = mount(<Root id={1} store={store} component={Connected} />);
+    inst.setProps({ hideConnected: true });
+
+    setTimeout(() => {
+      const state = store.getState();
+      state.test_unmounted.hasLoaded.should.equal(false);
+      state.test_unmounted.isPending.should.equal(false);
+      done();
+    }, 100);
+  });
+
+  it('should cancel all requests when the cancel is executed manually', (done) => {
+    fetchMock
+      .get('http://localhost/accumulated',
+        [{ id: 1, someprop: 'someval' }],
+        { delay: 1000, headers: { 'Content-Type': 'application/json' } });
+
+    const store = createStore((state) => state,
+      { okapi: { url: 'http://localhost', tenant: 'tenantid' } },
+      applyMiddleware(thunk));
+
+    const Connected = connect(Accumulated, 'test', mockedEpics, defaultLogger);
+    const inst = mount(<Root store={store} component={Connected} />);
+
+    inst.find(Accumulated).props().mutator.accumulated.GET();
+    inst.find(Accumulated).props().mutator.accumulated.cancel();
+
+    setTimeout(() => {
+      const state = store.getState();
+      state.test_accumulated.hasLoaded.should.equal(false);
+      state.test_accumulated.isPending.should.equal(false);
+      done();
+    }, 10);
   });
 });


### PR DESCRIPTION
### Purpose

This PR does 2 different things.

1. It will automatically cancel all pending requests (It will abort a promise) when the connected component unmounts.

2. It introduces a new method accessible via mutator called `cancel` (which can be used to manually cancel pending promises) to help in situations like the one in https://github.com/folio-org/ui-users/pull/1306/files where the child of the connected parent component unmounts.

### Link

https://issues.folio.org/browse/STCON-104

### Approach

I started with `cancelable` promise as described here first:

https://reactjs.org/blog/2015/12/16/ismounted-antipattern.html

but then discovered that some people complained about memory leakage with that approach under: https://github.com/facebook/react/issues/5465

Then based on the suggestion from @NikitaSedyx  in https://github.com/folio-org/ui-users/pull/1306 I took a look at `AbortController` https://developers.google.com/web/updates/2017/09/abortable-fetch

This seemed more straightforward and it looks like a more popular approach recently:
https://dev.to/bil/using-abortcontroller-with-react-hooks-and-typescript-to-cancel-window-fetch-requests-1md4

### Example

The example from https://github.com/folio-org/ui-users/pull/1306/files could be rewritten with:

````js

componentWillUnmount() {
  const { mutator: { openAccountsCount, closedAccountsCount } } = this.props;

  openAccountsCount.cancel();
  closedAccountsCount.cancel();
}
````

With hooks this would look like:

````js
useEffect(() => () = {
  openAccountsCount.cancel();
  closedAccountsCount.cancel();
}, []);

````

