### PR TITLE
STCON-112: Allow mutators to configure `throwErrors` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for stripes-connect
 
 ## 6.0.0 (IN PROGRESS)
+Allow mutators to configure `throwErrors` option. STCON-112.
 
 ## [5.6.1](https://github.com/folio-org/stripes-connect/tree/v5.6.1) (2020-06-08)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v5.6.0...v5.6.1)

--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -519,7 +519,7 @@ export default class RESTResource {
     }).then((response) => {
       if (response.status >= 400) {
         const clonedResponse = response.clone();
-        dispatch(this.mutationHTTPError(response, 'POST'));
+        dispatch(this.mutationHTTPError(response, 'POST', this.getActionMeta(options.POST)));
         // fetch responses are single-use so we use the one above and throw a different
         // one for catch() to play with
         throw clonedResponse;
@@ -549,10 +549,10 @@ export default class RESTResource {
         // single-use promise for getting them message body available for external
         // catch()
         if (!reason.status && !reason.headers) {
-          dispatch(this.actions.mutationError({ message: reason.message }, 'POST'));
+          dispatch(this.actions.mutationError({ message: reason.message }, 'POST', this.getActionMeta(options.POST)));
         }
       } else {
-        dispatch(this.actions.mutationError({ message: reason }, 'POST'));
+        dispatch(this.actions.mutationError({ message: reason }, 'POST', this.getActionMeta(options.POST)));
       }
     });
 
@@ -576,7 +576,7 @@ export default class RESTResource {
         .then((response) => {
           if (response.status >= 400) {
             const clonedResponse = response.clone();
-            dispatch(this.mutationHTTPError(response, 'PUT'));
+            dispatch(this.mutationHTTPError(response, 'PUT', this.getActionMeta(options.PUT)));
             throw clonedResponse;
           } else {
             const meta = this.getMeta({ ...options, ...opts });
@@ -604,7 +604,7 @@ export default class RESTResource {
 
       beforeCatch.catch((reason) => {
         if (typeof reason === 'object' && !reason.status && !reason.headers) {
-          dispatch(this.actions.mutationError({ message: reason.message }, 'PUT'));
+          dispatch(this.actions.mutationError({ message: reason.message }, 'PUT', this.getActionMeta(options.PUT)));
         }
       });
 
@@ -628,7 +628,7 @@ export default class RESTResource {
       .then((response) => {
         if (response.status >= 400) {
           const clonedResponse = response.clone();
-          dispatch(this.mutationHTTPError(response, 'DELETE'));
+          dispatch(this.mutationHTTPError(response, 'DELETE', this.getActionMeta(options.DELETE)));
           throw clonedResponse;
         } else {
           const meta = this.getMeta({ ...options, ...opts });
@@ -638,7 +638,7 @@ export default class RESTResource {
 
     beforeCatch.catch((reason) => {
       if (typeof reason === 'object' && !reason.status && !reason.headers) {
-        dispatch(this.mutationError({ message: reason.message }, 'DELETE'));
+        dispatch(this.actions.mutationError({ message: reason.message }, 'DELETE', this.getActionMeta(options.DELETE)));
       }
     });
 
@@ -892,10 +892,14 @@ export default class RESTResource {
     }));
   });
 
-  mutationHTTPError = (res, mutator) => dispatch => res.text().then((text) => {
+  mutationHTTPError = (res, mutator, meta) => dispatch => res.text().then((text) => {
     dispatch(this.actions.mutationError({
       message: text || res.statusText,
       httpStatus: res.status,
-    }, mutator));
+    }, mutator, meta));
   });
+
+  getActionMeta = actionOptions => {
+    return _.pick(actionOptions, 'throwErrors');
+  }
 }

--- a/RESTResource/actionCreatorsFor.js
+++ b/RESTResource/actionCreatorsFor.js
@@ -28,10 +28,10 @@ export default function actionCreatorsFor(resource) {
 
     deleteSuccess: passMetaPayload('DELETE_SUCCESS'),
 
-    mutationError: (err, mutator) => ({
+    mutationError: (err, mutator, meta) => ({
       type: '@@stripes-connect/MUTATION_ERROR',
       payload: { type: mutator, ...err },
-      meta: commonMeta,
+      meta: Object.assign({}, commonMeta, meta),
     }),
 
     fetchStart: passPayload('FETCH_START'),


### PR DESCRIPTION
## Purpose

Right now there is no possibility to override *throwErrors* option for a certain mutator which would be nice so an error is shown for all resource actions except the certain mutator for a which a custom solution implemented (e.g. callouts). In order to disable the error alert right now, *throwErrors* flag should be set for the whole resource, which is not good as it would be nice to show error alerts for other actions (e.g. *GET* requests) by default. The idea of the [STCON-112](https://issues.folio.org/browse/STCON-112) story is to provide the possibility to override resource *throwErrors* value for mutators: *POST*, *PUT*, *DELETE*.

```
  mappingProfile: {
    type: 'okapi',
    path: 'data-export/mappingProfiles/:{id}',
    PUT: { throwErrors: false },
  }
```