### PR TITLE
provide OkapiLookupResource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Change history for stripes-connect
 
 ## 6.0.0 (IN PROGRESS)
-Allow mutators to configure `throwErrors` option. STCON-112.
+
+* Allow mutators to configure `throwErrors` option. STCON-112.
+* Provide `OkapiLookupResource`, automatically providing a limit clause on lookup queries.
 
 ## [5.6.1](https://github.com/folio-org/stripes-connect/tree/v5.6.1) (2020-06-08)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v5.6.0...v5.6.1)

--- a/OkapiLookupResource.js
+++ b/OkapiLookupResource.js
@@ -1,0 +1,81 @@
+import RESTResource from './RESTResource';
+
+const MAX_RECORDS = '2000';
+
+const defaults = {
+  pk: 'id',
+  clientGeneratePk: true,
+  fetch: true,
+  clear: true,
+  limitParam: 'limit',
+  offsetParam: 'offset',
+  headers: {
+  },
+  POST: {
+    headers: {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json',
+    },
+  },
+  DELETE: {
+    headers: {
+      'Accept': 'text/plain',
+      'Content-Type': 'application/json',
+    },
+  },
+  GET: {
+    headers: {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json',
+    },
+    params: {
+      'limit': MAX_RECORDS,
+    }
+  },
+  PUT: {
+    headers: {
+      'Accept': 'text/plain',
+      'Content-Type': 'application/json',
+    },
+  },
+};
+
+function optionsFromState(options, state) {
+  if (options.type === 'lookup') {
+    if (typeof state.okapi !== 'object') {
+      throw new Error('State does not contain Okapi settings');
+    }
+    const okapiOptions = {
+      root: state.okapi.url,
+      headers: {
+        'X-Okapi-Tenant': state.okapi.tenant,
+      },
+    };
+    if (state.okapi.token) okapiOptions.headers['X-Okapi-Token'] = state.okapi.token;
+    return okapiOptions;
+  }
+  return {};
+}
+
+export default class OkapiLookupResource extends RESTResource {
+  constructor(name, query = {}, module = null, logger, dataKey) {
+    query.optionsFromState = optionsFromState;
+
+    super(name, query, module, logger, dataKey, defaults);
+    this.visibleCount = 0;
+  }
+
+  markVisible() {
+    this.visibleCount += 1;
+  }
+
+  markInvisible() {
+    if (this.visibleCount > 0) {
+      this.visibleCount -= 1;
+    }
+  }
+
+  isVisible() {
+    return this.visibleCount > 0;
+  }
+}

--- a/connect.js
+++ b/connect.js
@@ -5,6 +5,7 @@ import { connect as reduxConnect } from 'react-redux';
 import { withConnect } from './ConnectContext';
 
 import OkapiResource from './OkapiResource';
+import OkapiLookupResource from './OkapiLookupResource';
 import RESTResource from './RESTResource';
 import { initialResourceState } from './RESTResource/reducer';
 import LocalResource from './LocalResource';
@@ -16,6 +17,7 @@ const types = {
   local: LocalResource,
   okapi: OkapiResource,
   rest: RESTResource,
+  lookup: OkapiLookupResource,
 };
 
 const excludedProps = ['anyTouched', 'mutator', 'connectedSource'];


### PR DESCRIPTION
A `lookup` resource is a straight clone of `OkapiResource` with one
exception: it provides a limit clause to `GET` queries by default so
that we never again, not EVER, have to worry about accidentally
forgetting to provide one and retrieving only 10 records. It is
hard-coded to retrieve 2000 items.

If your lookup table has more than 2000 items in it, you probably
shouldn't be treating it as an ordinary lookup table because you need to
worry about paging and such like. This isn't for you.