### PR TITLE
STCON-115 Added additional check to see if params is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change history for stripes-connect
 
+## 6.1.0 IN PROGRESS
+
 ## [6.0.0](https://github.com/folio-org/stripes-connect/tree/v6.0.0) (2020-10-06)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v5.6.1...v6.0.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for stripes-connect
 
 ## 6.1.0 IN PROGRESS
+* Added additional check to not trigger a fetch when params is null, refs STCON-115
 
 ## [6.0.0](https://github.com/folio-org/stripes-connect/tree/v6.0.0) (2020-10-06)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v5.6.1...v6.0.0)

--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -354,6 +354,10 @@ export default class RESTResource {
       }
     }
 
+    /* if params is not null and perRequest is passed as an option, then add the limit param and trigger a fetch.
+       If params is returned as null, then do not add the limit param and prevent a fetch.
+       NOTE: If params is undefined (default case when params option is not passed to the resource via the manifest),
+       the limit param is added and triggers a fetch like it should. */
     if (options.params !== null && options.perRequest && options.limitParam && verb === 'GET') {
       options.params = _.merge({}, options.params, { [options.limitParam]: options.perRequest });
     }

--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -354,7 +354,7 @@ export default class RESTResource {
       }
     }
 
-    if (options.perRequest && options.limitParam && verb === 'GET') {
+    if (options.params !== null && options.perRequest && options.limitParam && verb === 'GET') {
       options.params = _.merge({}, options.params, { [options.limitParam]: options.perRequest });
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-connect",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "Declarative REST data access for React components",
   "repository": "folio-org/stripes-connect",
   "sideEffects": [


### PR DESCRIPTION
Stripes-connect allows us to return a `null` value as a part of the `params` option. For eg: [here](https://github.com/folio-org/ui-agreements/blob/master/src/routes/AgreementEditRoute.js#L121). I believe the general understanding is that returning `null` from `params` means the `url` to be built is incomplete and hence is returned as `null` and the fetch is not triggered. But, currently adding the `perRequest` [option](https://github.com/folio-org/ui-agreements/blob/master/src/routes/AgreementEditRoute.js#L114) to the manifest by-passes this idea and triggers a fetch by adding a `limit` param to the url. 

Considering that the `params` options should be the single source of truth and returning `null` shouldn't trigger a fetch, this PR fixes that issue by adding an additional null check.

Refs [STCON-115](https://issues.folio.org/browse/STCON-115)