### PR TITLE
Extend the perRequest option to accept a string or a function, refs STCON…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 6.1.0 IN PROGRESS
 * Added additional check to not trigger a fetch when params is null, refs STCON-115
-
+* Perform substitutions on perRequest option, refs STCON-117
 ## [6.0.0](https://github.com/folio-org/stripes-connect/tree/v6.0.0) (2020-10-06)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v5.6.1...v6.0.0)
 

--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -359,6 +359,9 @@ export default class RESTResource {
        NOTE: If params is undefined (default case when params option is not passed to the resource via the manifest),
        the limit param is added and triggers a fetch like it should. */
     if (options.params !== null && options.perRequest && options.limitParam && verb === 'GET') {
+      if (typeof options.perRequest === 'string' || typeof options.perRequest === 'function') {
+        options.perRequest = substitute(options.perRequest, props, state, this.module, this.logger, this.dataKey);
+      }
       options.params = _.merge({}, options.params, { [options.limitParam]: options.perRequest });
     }
 

--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -360,7 +360,12 @@ export default class RESTResource {
        the limit param is added and triggers a fetch like it should. */
     if (options.params !== null && options.perRequest && options.limitParam && verb === 'GET') {
       if (typeof options.perRequest === 'string' || typeof options.perRequest === 'function') {
-        options.perRequest = substitute(options.perRequest, props, state, this.module, this.logger, this.dataKey);
+        const perRequest = Number.parseInt(substitute(options.perRequest, props, state, this.module, this.logger, this.dataKey), 10);
+        if (perRequest >= 0) {
+          options.perRequest = perRequest;
+        } else {
+          return options;
+        }
       }
       options.params = _.merge({}, options.params, { [options.limitParam]: options.perRequest });
     }


### PR DESCRIPTION
…-117, ERM-1190.

Currently, the `perRequest` option thats used to specify the number of results to be fetched per request can only be a hardcoded number and there is no way for us to fetch this value dynamically either via  a local resource or a tenant level setting as required by https://issues.folio.org/browse/ERM-1190. 

This PR extends the ability to pass either a [callback](https://github.com/folio-org/stripes-connect/blob/master/RESTResource/RESTResource.js#L245)  or a string that lets us [process string template](https://github.com/folio-org/stripes-connect/blob/master/RESTResource/RESTResource.js#L174)