### PR TITLE
STRIPES-721: Upgrade to react-redux 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
     "lodash": "^4.17.11",
     "prop-types": "^15.5.10",
     "query-string": "^5.0.0",
-    "react-redux": "^5.0.2",
-    "redux": "^3.6.0",
+    "react-redux": "^7.2.0",
+    "redux": "^4.0.0",
     "uuid": "^3.0.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
This is part one of the PRs required to upgrade to react-redux 7 in Stripes.

I'm not sure if we'll be able to get CI builds passing in every repo during the process, but if it's possible, it'll probably be with PR merges in this order:

- [ ] [stripes-connect](https://github.com/folio-org/stripes-connect/pull/163)
- [ ] [stripes-core](https://github.com/folio-org/stripes-core/pull/985) and [stripes-components](https://github.com/folio-org/stripes-components/pull/1484)
- [ ] [stripes-smart-components](https://github.com/folio-org/stripes-smart-components/pull/981) and [stripes-form](https://github.com/folio-org/stripes-form/pull/135)
- [ ] [stripes](https://github.com/folio-org/stripes/pull/114)
- [ ] platforms