### PR TITLE
STCON-119 bump major to v7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change history for stripes-connect
 
-## 6.1.0 IN PROGRESS
+## 7.0.0 IN PROGRESS
 
 * Added additional check to not trigger a fetch when params is null, refs STCON-115
 * Perform substitutions on perRequest option, refs STCON-117

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-connect",
-  "version": "6.1.0",
+  "version": "7.0.0",
   "description": "Declarative REST data access for React components",
   "repository": "folio-org/stripes-connect",
   "sideEffects": [


### PR DESCRIPTION
Bumping the major version of a peer-dep requires bumping your own major
version too. Whoops.

Refs [STCON-119](https://issues.folio.org/browse/STCON-119)