### PR TITLE
STRIPES-722 Revert "STCON-119 bump major to v7"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change history for stripes-connect
 
-## 7.0.0 IN PROGRESS
+## 6.1.0 IN PROGRESS
 
 * Added additional check to not trigger a fetch when params is null, refs STCON-115
 * Perform substitutions on perRequest option, refs STCON-117

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-connect",
-  "version": "7.0.0",
+  "version": "6.1.0",
   "description": "Declarative REST data access for React components",
   "repository": "folio-org/stripes-connect",
   "sideEffects": [


### PR DESCRIPTION
Reverts folio-org/stripes-connect#166 (major version bump) ... in prep for reverting #165 (increment to react v17), due to unforeseen problems with testing.

Crackerjack research by @aditya-matukumalli and @mkuklis suggests [onFocus changes in React 17](https://github.com/facebook/react/issues/19743), which have caused [event handling trouble for others](https://eng.wealthfront.com/2021/01/14/upgrading-to-react-17-how-to-fix-the-issues-and-breaking-changes/), may be causing [our woes](https://issues.folio.org/browse/STCOR-504) too. 

Refs [STRIPES-722](https://issues.folio.org/browse/STRIPES-722)