### PR TITLE
Cause headers to be substituted

### DIFF
--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -324,6 +324,17 @@ export default class RESTResource {
         options.params = options.params(parsedQuery, _.get(props, ['match', 'params']), mockProps(state, this.module, props.dataKey, this.logger).resources, this.logger, props);
       }
 
+      // headers
+      if (typeof options.headers === 'object') {
+        options.headers = _.mapValues(
+          options.headers,
+          header => substitute(header, props, state, this.module, this.logger, this.dataKey)
+        );
+      } else if (typeof options.headers === 'function') {
+        const parsedQuery = queryString.parse(_.get(props, ['location', 'search']));
+        options.headers = options.headers(parsedQuery, _.get(props, ['match', 'params']), mockProps(state, this.module, props.dataKey, this.logger).resources, this.logger, props);
+      }
+
       // recordsRequired
       if (typeof options.recordsRequired === 'string' || typeof options.recordsRequired === 'function') {
         const tmplReqd = Number.parseInt(substitute(options.recordsRequired, props, state, this.module, this.logger, this.dataKey), 10);

--- a/test/RESTResource.js
+++ b/test/RESTResource.js
@@ -20,6 +20,7 @@ const props = {
   location: {
     search: '?q=water',
   },
+  headerVal: 'my_header_val'
 };
 const module = 'somemodule';
 
@@ -41,6 +42,11 @@ describe('RESTResource', () => {
     it('replaces query parameters', () => {
       substitute('/whatever/?{q}/anyways', ...args)
         .should.equal('/whatever/water/anyways');
+    });
+
+    it('replaces header values', () => {
+      substitute('!{headerVal}', ...args)
+        .should.equal('my_header_val');
     });
 
     it('replaces resources', () => {


### PR DESCRIPTION
It is conceivable that a request may contain headers that need value
substitution to take place (as per query parameters, path components
etc.). The use case this was implemented for was to allow an external
API key, that was being passed down to a component as a prop, to be used
in an authentication header for an API call being made by the child
component.