### PR TITLE
Revert "STCON-121: Allow 'headers' to be a function and interpreted"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Change history for stripes-connect
 
-## (IN PROGRESS)
-
-* Added the ability for elements of a manifest 'headers' property to be interpreted, and also to be a function in addition to an object. Refs STCON-121
-
 ## [6.1.0](https://github.com/folio-org/stripes-connect/tree/v6.1.0) (2021-02-25)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v6.0.0...v6.1.0)
 

--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -256,39 +256,6 @@ export function substitute(original, props, state, module, logger, dataKey) {
   return result;
 }
 
-/**
- * buildOption
- * Some manifest options properties may be an object or a function, determine which
- * the passed property is and act accordingly
- *
- * @param option object or function
- * @param props object
- * @param state object
- * @param module string name of the module the resource is affiliated with
- * @param logger object a logger
- * @param dataKey string unique key to disambiguate this resource from another
- * which otherwise has the same attributes
- *
- * @return object
- */
-
-export function buildOption(option, props, state, module, logger, dataKey) {
-  let toReturn;
-  if (typeof option === 'object') {
-    // If any of the option properties have null values, we can't go any further
-    const someParamIsNull = Object.values(option).some(value => value === null);
-    if (someParamIsNull) return null;
-    toReturn = _.mapValues(
-      option,
-      param => substitute(param, props, state, module, logger, dataKey)
-    );
-  } else if (typeof option === 'function') {
-    const parsedQuery = queryString.parse(props.location?.search);
-    toReturn = option(parsedQuery, props.match?.params, mockProps(state, module, dataKey, logger).resources, logger, props);
-  }
-  return toReturn;
-}
-
 export default class RESTResource {
   constructor(name, query = {}, module = null, logger, dataKey, defaults = defaultDefaults) {
     this.name = name;
@@ -342,10 +309,20 @@ export default class RESTResource {
       }
 
       // params
-      options.params = buildOption(options.params, props, state, this.module, this.logger, this.dataKey);
-
-      // headers
-      options.headers = buildOption(options.headers, props, state, this.module, this.logger, this.dataKey);
+      if (typeof options.params === 'object') {
+        options.params = _.mapValues(
+          options.params,
+          param => substitute(param, props, state, this.module, this.logger, this.dataKey)
+        );
+        for (const key of Object.keys(options.params)) {
+          if (options.params[key] === null) {
+            return null;
+          }
+        }
+      } else if (typeof options.params === 'function') {
+        const parsedQuery = queryString.parse(_.get(props, ['location', 'search']));
+        options.params = options.params(parsedQuery, _.get(props, ['match', 'params']), mockProps(state, this.module, props.dataKey, this.logger).resources, this.logger, props);
+      }
 
       // recordsRequired
       if (typeof options.recordsRequired === 'string' || typeof options.recordsRequired === 'function') {

--- a/doc/api.md
+++ b/doc/api.md
@@ -381,10 +381,10 @@ generated path when no sorting parameter is provided in the UI URL.
 
 When the power and flexibility of text substitution and fallbacks are not
 sufficient for expressing how to build the back-end UI, arbitrary
-JavaScript can be used instead. If the value of a resource's `path`,
-or one of its `params` or `headers` is a function rather than a string, then
-that function is invoked whenever a path is needed. It is passed five
-parameters (though most functions will not use them all):
+JavaScript can be used instead. If the value of a resource's `path` or one
+of its `params` is a function rather than a string, then that function is
+invoked whenever a path is needed. It is passed five parameters
+(though most functions will not use them all):
 
 * An object containing the UI URL's query parameters (as accessed by
   `?{name}`).
@@ -418,10 +418,9 @@ So the function would usually be defined along these lines:
           }
         });
 
-Similarly, the entire `params` and `headers` objects can be replaced by a
-function that takes the above arguments and returns, instead of a string,
-an object to map to the parameters to be sent with requests. Or null if
-it lacks necessary information.
+Similarly, the entire `params` object can be replaced by a function that takes
+the above arguments and returns, instead of a string, an object to map to the
+parameters to be sent with requests. Or null if it lacks necessary information.
 
 
 

--- a/test/RESTResource.js
+++ b/test/RESTResource.js
@@ -1,7 +1,7 @@
 import { should, expect } from 'chai';
 import { describe, it } from 'mocha';
 
-import { substitute, buildOption } from '../RESTResource/RESTResource';
+import { substitute } from '../RESTResource/RESTResource';
 
 should();
 
@@ -20,11 +20,6 @@ const props = {
   location: {
     search: '?q=water',
   },
-  holding: {
-    id: '1234'
-  },
-  propVal: 'my_prop_value'
-
 };
 const module = 'somemodule';
 
@@ -55,11 +50,6 @@ describe('RESTResource', () => {
         .should.equal('innerstring');
     });
 
-    it('performs prop substitution', () => {
-      substitute('!{propVal}', ...args) // eslint-disable-line no-template-curly-in-string
-        .should.equal('my_prop_value');
-    });
-
     it('handles multiple', () => {
       substitute('/?{q}/${top}/:{id}', ...args) // eslint-disable-line no-template-curly-in-string
         .should.equal('/water/somestring/42');
@@ -75,24 +65,6 @@ describe('RESTResource', () => {
         .to.equal(null);
       expect(substitute(() => undefined, ...args))
         .to.equal(undefined);
-    });
-  });
-
-  describe('buildOption()', () => {
-    it('builds an option derived from a manifest object', () => {
-      buildOption({ query: 'holdingsRecordId==!{holding.id}' }, ...args)
-        .should.eql({ query: 'holdingsRecordId==1234' });
-    });
-    it('builds an option derived from a manifest callback', () => {
-      const callback = (parsedQuery, params, resources, logger, cbProps) => ({ // eslint-disable-line no-unused-vars
-        parsedQuery,
-        params
-      });
-      buildOption(callback, ...args)
-        .should.eql({
-          parsedQuery: { q: 'water' },
-          params: { id: '42' }
-        });
     });
   });
 });


### PR DESCRIPTION
Reverts folio-org/stripes-connect#173

I'm not sure of the exact mechanism, but #173 is causing resources that used to return `null` not to, causing them to execute when they should not. For example, visiting ui-users causes the query 
```
/users?limit=100&query
```
to run automatically, even though the `query` attribute is empty. This results in a 400 response from Okapi which the UI relays in a JS alert: 
```
ERROR: in module @folio/users, operation GET on resource 'records' failed, saying: org.folio.cql2pgjson.exception.QueryValidationException: 
org.z3950.zing.cql.CQLParseException: expected index or term, got EOF
```
because it expected a URL like 
```
/users?limit=100&query=some-value
```
but the emptiness of `value` is what should have prevented the query from running in the first place. 

attn: @AndrewIsh 