### PR TITLE
STCON-123: Introduce result density option for pagination component 

### DIFF
--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -4,6 +4,7 @@ import queryString from 'query-string';
 
 import actionCreatorsFor from './actionCreatorsFor';
 import reducer from './reducer';
+import { resultDensities } from '../constants';
 
 const defaultDefaults = {
   pk: 'id',
@@ -12,6 +13,7 @@ const defaultDefaults = {
   clear: true,
   abortable: false,
   abortOnUnmount: false,
+  resultDensity: resultDensities.DENSE,
 };
 
 /**
@@ -829,7 +831,7 @@ export default class RESTResource {
 
   // Fetches a single page by offset adding it to the existing result list in redux
   fetchPageByOffset = (options, total) => {
-    const { headers, records, resultOffset, offsetParam, outputFormat } = options;
+    const { headers, records, resultOffset, offsetParam } = options;
     const reqd = Math.min(resultOffset, total);
     const key = this.stateKey();
 
@@ -866,7 +868,8 @@ export default class RESTResource {
               };
               if (meta.other) meta.other.totalRecords = extractTotal(json);
               const data = (records ? json[records] : json);
-              if (!options.accumulate) {
+
+              if (options.resultDensity === resultDensities.SPARSE) {
                 dispatch(this.actions.offsetFetchSparseSliceSuccess(meta, data));
               } else {
                 dispatch(this.actions.offsetFetchSuccess(meta, data));

--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -829,7 +829,7 @@ export default class RESTResource {
 
   // Fetches a single page by offset adding it to the existing result list in redux
   fetchPageByOffset = (options, total) => {
-    const { headers, records, resultOffset, offsetParam } = options;
+    const { headers, records, resultOffset, offsetParam, outputFormat } = options;
     const reqd = Math.min(resultOffset, total);
     const key = this.stateKey();
 
@@ -866,7 +866,11 @@ export default class RESTResource {
               };
               if (meta.other) meta.other.totalRecords = extractTotal(json);
               const data = (records ? json[records] : json);
-              dispatch(this.actions.offsetFetchSuccess(meta, data));
+              if (!options.accumulate) {
+                dispatch(this.actions.offsetFetchSparseSliceSuccess(meta, data));
+              } else {
+                dispatch(this.actions.offsetFetchSuccess(meta, data));
+              }
             });
           }
         }).catch((reason) => this.handleFetchOrAbortError(reason, dispatch));

--- a/RESTResource/actionCreatorsFor.js
+++ b/RESTResource/actionCreatorsFor.js
@@ -42,6 +42,8 @@ export default function actionCreatorsFor(resource) {
 
     offsetFetchSuccess: passMetaPayload('OFFSET_FETCH_SUCCESS'),
 
+    offsetFetchSparseSliceSuccess: passMetaPayload('OFFSET_FETCH_SPARSE_SLICE_SUCCESS'),
+
     fetchError: passPayload('FETCH_ERROR'),
 
     fetchAbort: passPayload('FETCH_ABORT'),

--- a/RESTResource/reducer.js
+++ b/RESTResource/reducer.js
@@ -48,8 +48,10 @@ export default function (state = initialResourceState, action) {
     }
     case '@@stripes-connect/OFFSET_FETCH_SUCCESS': {
       const records = [...state.records];
-      if (Array.isArray(action.payload)) records.splice(action.meta.offset, 0, ...action.payload);
-      else records.splice(action.meta.offset, 0, _.clone(action.payload));
+      // Extend length of array to offset, so if skipping ahead, array is padded with 'undefined' entries.
+      records[action.meta.offset] = null;
+      if (Array.isArray(action.payload)) records.splice(action.meta.offset, 1, ...action.payload);
+      else records.splice(action.meta.offset, 1, _.clone(action.payload));
       return Object.assign({}, state, {
         hasLoaded: true,
         loadedAt: new Date(),

--- a/RESTResource/reducer.js
+++ b/RESTResource/reducer.js
@@ -60,19 +60,23 @@ export default function (state = initialResourceState, action) {
       });
     }
     case '@@stripes-connect/OFFSET_FETCH_SPARSE_SLICE_SUCCESS': {
-      let tempArray;
+      let tempArray = [];
+      let remove = 0;
+
       if (Array.isArray(action.payload)) {
         let dataLength = action.meta.offset;
-        let remove = 0;
+
         if (action.meta.offset < state.records.length) {
           dataLength = state.records.length;
           remove = action.payload.length;
         }
+
         tempArray = new Array(dataLength);
         tempArray.splice(action.meta.offset, remove, ...action.payload);
       } else {
-        tempArray.splice(action.meta.offset, 0, _.clone(action.payload));
+        tempArray.splice(action.meta.offset, remove, _.clone(action.payload));
       }
+
       return Object.assign({}, state, {
         hasLoaded: true,
         loadedAt: new Date(),

--- a/RESTResource/reducer.js
+++ b/RESTResource/reducer.js
@@ -48,16 +48,37 @@ export default function (state = initialResourceState, action) {
     }
     case '@@stripes-connect/OFFSET_FETCH_SUCCESS': {
       const records = [...state.records];
-
-      let tempArray = new Array(action.meta.offset);
-      if (Array.isArray(action.payload)) tempArray.splice(action.meta.offset, 0, ...action.payload);
-      else tempArray.splice(action.meta.offset, 0, _.clone(action.payload));
+      if (Array.isArray(action.payload)) records.splice(action.meta.offset, 0, ...action.payload);
+      else records.splice(action.meta.offset, 0, _.clone(action.payload));
       return Object.assign({}, state, {
         hasLoaded: true,
         loadedAt: new Date(),
         isPending: false,
         failed: false,
         records,
+        ...action.meta,
+      });
+    }
+    case '@@stripes-connect/OFFSET_FETCH_SPARSE_SLICE_SUCCESS': {
+      let tempArray;
+      if (Array.isArray(action.payload)) {
+        let dataLength = action.meta.offset;
+        let remove = 0;
+        if (action.meta.offset < state.records.length) {
+          dataLength = state.records.length;
+          remove = action.payload.length;
+        }
+        tempArray = new Array(dataLength);
+        tempArray.splice(action.meta.offset, remove, ...action.payload);
+      } else {
+        tempArray.splice(action.meta.offset, 0, _.clone(action.payload));
+      }
+      return Object.assign({}, state, {
+        hasLoaded: true,
+        loadedAt: new Date(),
+        isPending: false,
+        failed: false,
+        records: tempArray,
         ...action.meta,
       });
     }

--- a/RESTResource/reducer.js
+++ b/RESTResource/reducer.js
@@ -48,10 +48,10 @@ export default function (state = initialResourceState, action) {
     }
     case '@@stripes-connect/OFFSET_FETCH_SUCCESS': {
       const records = [...state.records];
-      // Extend length of array to offset, so if skipping ahead, array is padded with 'undefined' entries.
-      records[action.meta.offset] = null;
-      if (Array.isArray(action.payload)) records.splice(action.meta.offset, 1, ...action.payload);
-      else records.splice(action.meta.offset, 1, _.clone(action.payload));
+
+      let tempArray = new Array(action.meta.offset);
+      if (Array.isArray(action.payload)) tempArray.splice(action.meta.offset, 0, ...action.payload);
+      else tempArray.splice(action.meta.offset, 0, _.clone(action.payload));
       return Object.assign({}, state, {
         hasLoaded: true,
         loadedAt: new Date(),

--- a/babel-test-hook.js
+++ b/babel-test-hook.js
@@ -2,6 +2,7 @@ require('@babel/register')({
   plugins: [
     ['@babel/plugin-proposal-decorators', { 'legacy': true }],
     ['@babel/plugin-proposal-class-properties', { 'loose': true }],
+    ['@babel/plugin-proposal-private-methods', { 'loose': true }],
     '@babel/plugin-proposal-export-namespace-from',
     '@babel/plugin-proposal-function-sent',
     '@babel/plugin-proposal-numeric-separator',

--- a/constants.js
+++ b/constants.js
@@ -1,0 +1,6 @@
+export const resultDensities = {
+  DENSE: 'dense',
+  SPARSE: 'sparse',
+};
+
+export default {};


### PR DESCRIPTION
https://issues.folio.org/browse/STCON-123

This PR is a continuation of the work @JohnC-80 and @ryandberger did under https://github.com/folio-org/stripes-connect/tree/sparse-array-option. 
It introduces a new manifest option called `resultDensity` which defaults to `dense`. In order to opt-in for pagination the `resultDensity` can be set to `sparse`. 