### PR TITLE
STCON-127 provide Accept-Language header to OkapiResource requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 6.2.0 (IN PROGRESS)
 
 * Added the ability for elements of a manifest 'headers' property to be interpreted, and also to be a function in addition to an object. Refs STCON-121
+* Provide tenant's locale in `Accept-Language` HTTP header of `OkapiResource` requests. Refs STCON-127.
 
 ## [6.1.0](https://github.com/folio-org/stripes-connect/tree/v6.1.0) (2021-02-25)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v6.0.0...v6.1.0)

--- a/OkapiResource.js
+++ b/OkapiResource.js
@@ -46,7 +46,7 @@ function optionsFromState(options, state) {
       root: state.okapi.url,
       headers: {
         'X-Okapi-Tenant': state.okapi.tenant,
-        'Accept-Language': state.okapi.locale,
+        'Accept-Language': state.okapi.locale ?? 'en',
       },
     };
     if (state.okapi.token) okapiOptions.headers['X-Okapi-Token'] = state.okapi.token;

--- a/OkapiResource.js
+++ b/OkapiResource.js
@@ -46,6 +46,7 @@ function optionsFromState(options, state) {
       root: state.okapi.url,
       headers: {
         'X-Okapi-Tenant': state.okapi.tenant,
+        'Accept-Language': state.okapi.locale,
       },
     };
     if (state.okapi.token) okapiOptions.headers['X-Okapi-Token'] = state.okapi.token;


### PR DESCRIPTION
Provide the tenant's locale setting in the HTTP `Accept-Language` header
to `OkapiResource` requests. This is the standard way for an HTTP client
to indicate the languages it understands.

See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language

Refs [STCON-127](https://issues.folio.org/browse/STCON-127), [STRIPES-750](https://issues.folio.org/browse/STRIPES-750)