### PR TITLE
STCON-130 update many outdated dependencies

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,6 @@
 {
   "extends": "@folio/eslint-config-stripes",
-  "parser": "babel-eslint",
+  "parser": "@babel/eslint-parser",
   "rules": {
     "prefer-object-spread": "off"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 7.0.0 (IN PROGRESS)
 
 * React 17. STCON-119.
+* Use current eslint-parser, eslint, fetch-mock, jsdom, uuid. Refs STCON-130.
 
 ## [6.2.0](https://github.com/folio-org/stripes-connect/tree/v6.2.0) (2021-06-08)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v6.1.0...v6.2.0)

--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import uuid from 'uuid';
+import { v4 as uuidv4 } from 'uuid';
 import queryString from 'query-string';
 
 import actionCreatorsFor from './actionCreatorsFor';
@@ -577,7 +577,7 @@ export default class RESTResource {
     const url = urlFromOptions(options);
     if (url === null) return null; // needs dynamic parts that aren't available
     // Optimistic record creation ('clientRecord')
-    const clientGeneratedId = record.id ? record.id : uuid();
+    const clientGeneratedId = record.id ? record.id : uuidv4();
     const clientRecord = { ...record, id: clientGeneratedId };
     clientRecord[pk] = clientGeneratedId;
     dispatch(this.actions.createStart(clientRecord));

--- a/RESTResource/reducer.js
+++ b/RESTResource/reducer.js
@@ -10,7 +10,7 @@ export const initialResourceState = {
   pendingMutations: [],
 };
 
-export default function (state = initialResourceState, action) {
+export default function reducer(state = initialResourceState, action) {
   if (!action.type.startsWith('@@stripes-connect')
     || action.meta.module !== this.module
     || action.meta.resource !== this.name

--- a/babel-test-hook.js
+++ b/babel-test-hook.js
@@ -1,5 +1,6 @@
 require('@babel/register')({
   plugins: [
+    ['@babel/plugin-proposal-private-property-in-object', { 'loose': true }],
     ['@babel/plugin-proposal-decorators', { 'legacy': true }],
     ['@babel/plugin-proposal-class-properties', { 'loose': true }],
     ['@babel/plugin-proposal-private-methods', { 'loose': true }],

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.8.0",
+    "@babel/eslint-parser": "^7.15.0",
     "@babel/plugin-proposal-class-properties": "^7.0.0",
     "@babel/plugin-proposal-decorators": "^7.0.0",
     "@babel/plugin-proposal-export-namespace-from": "^7.0.0",
@@ -32,16 +33,15 @@
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-react": "^7.7.4",
     "@babel/register": "^7.7.7",
-    "@folio/eslint-config-stripes": "^5.1.0",
+    "@folio/eslint-config-stripes": "^6.0.0",
     "@wojtekmaj/enzyme-adapter-react-17": "^0.6.3",
     "abort-controller": "^3.0.0",
-    "babel-eslint": "^10.0.1",
     "chai": "^4.0.2",
     "core-js": "^3.6.1",
     "enzyme": "^3.3.0",
-    "eslint": "^6.2.1",
-    "fetch-mock": "9.10.1",
-    "jsdom": "^12.1.0",
+    "eslint": "^7.32.0",
+    "fetch-mock": "^9.10.1",
+    "jsdom": "^17",
     "jsdom-global": "^3.0.2",
     "mocha": "^6.1.3",
     "node-fetch": "^2.6.1",
@@ -56,7 +56,7 @@
     "query-string": "^5.0.0",
     "react-redux": "^7.2.0",
     "redux": "^4.0.0",
-    "uuid": "^3.0.1"
+    "uuid": "^8.3.2"
   },
   "peerDependencies": {
     "react": "^17.0.2",


### PR DESCRIPTION
Use current `eslint-parser`, `eslint`, `fetch-mock`, `jsdom`, `uuid`. I
just couldn't handle the build warnings any more. Of course now that
`eslint-config-stripes` relies on `stripes-webpack` for its config,
there are actually _more_ build warnings from that, Alas.

Refs [STCON-130](https://issues.folio.org/browse/STCON-130)