### PR TITLE
STCON-132: Refactor connect to use a functional component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-connect
 
+## [7.1.0] IN PROGRESS
+
+* Refactor connect to use a functional component. Refs STCON-132.
+
 ## [7.0.0](https://github.com/folio-org/stripes-connect/tree/v7.0.0) (2021-09-26)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v6.2.0...v7.0.0)
 

--- a/hooks/index.js
+++ b/hooks/index.js
@@ -1,0 +1,2 @@
+export { default as useComponentWillMount } from './useComponentWillMount';
+export { default as usePrevious } from './usePrevious';

--- a/hooks/useComponentWillMount.js
+++ b/hooks/useComponentWillMount.js
@@ -1,0 +1,16 @@
+import { useRef } from 'react';
+
+// A hook used to run a given callback
+// when component initializes before the first render
+const useComponentWillMount = callback => {
+  const willMount = useRef(true);
+
+  if (willMount.current) {
+    callback();
+  }
+
+  willMount.current = false;
+};
+
+
+export default useComponentWillMount;

--- a/hooks/usePrevious.js
+++ b/hooks/usePrevious.js
@@ -1,0 +1,15 @@
+import { useRef, useEffect } from 'react';
+
+// A hook which holds a previous value.
+// Useful to hold props from a previous render.
+const usePrevious = value => {
+  const ref = useRef();
+
+  useEffect(() => {
+    ref.current = value;
+  });
+
+  return ref.current;
+};
+
+export default usePrevious;


### PR DESCRIPTION
stripes-connect uses class based component with lifecycle methods which are deprecated and will be removed in react 18. 

We should try to refactor it to use a functional component.

https://issues.folio.org/browse/STCON-132
