### PR TITLE
Upgrade react-redux to v8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change history for stripes-connect
 
 ## 8.0.0 IN PROGRESS
-* Upgrade `react-redux` to `v8`. Refs STRIPES-834.
+* Upgrade `react-redux` to `v8`. Refs STCON-139.
 
 ## [7.1.0](https://github.com/folio-org/stripes-connect/tree/v7.1.0) (2022-06-14)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v7.0.0...v7.1.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for stripes-connect
 
+## 8.0.0 IN PROGRESS
+* Upgrade `react-redux` to `v8`. Refs STRIPES-834.
+
 ## [7.1.0](https://github.com/folio-org/stripes-connect/tree/v7.1.0) (2022-06-14)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v7.0.0...v7.1.0)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-connect",
-  "version": "7.1.0",
+  "version": "8.1.0",
   "description": "Declarative REST data access for React components",
   "repository": "folio-org/stripes-connect",
   "sideEffects": [
@@ -56,7 +56,7 @@
     "lodash": "^4.17.11",
     "prop-types": "^15.5.10",
     "query-string": "^7.1.2",
-    "react-redux": "^7.2.0",
+    "react-redux": "^8.0.5",
     "redux": "^4.0.0",
     "uuid": "^8.3.2"
   },


### PR DESCRIPTION
- Refs https://issues.folio.org/browse/STCON-139.
- Upgrade will be happening across all of Stripes framework and modules that reference `react-redux`.
- `v7` to `v8` is a very harmless upgrade and is only considered breaking since they removed a few rarely used functions (which I confirmed we don't use). See https://github.com/reduxjs/react-redux/releases/tag/v8.0.0 for more details.