### PR TITLE
STCON-144: Use index.js to correctly export public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-connect
 
+## 8.2.0 IN PROGRESS
+
+* Use `index.js` to correctly export public API. Refs STCON-144.
+
 ## [8.1.0](https://github.com/folio-org/stripes-connect/tree/v8.1.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v7.1.0...v8.1.0)
 

--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+export { default } from './connect';
+export * from './connect';
+export { compilePathTemplate } from './RESTResource/RESTResource';

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "publishConfig": {
     "registry": "https://repository.folio.org/repository/npm-folio/"
   },
-  "main": "connect.js",
+  "main": "index.js",
   "author": "Index Data",
   "license": "Apache-2.0",
   "engines": {


### PR DESCRIPTION
Use `index.js` to correctly export public API.
https://issues.folio.org/browse/STCON-144