### PR TITLE
STCON-145: Cleanup dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Introduce transpilation. Fixes STCON-140.
 * Use `index.js` to correctly export public API. Refs STCON-144.
+* Cleanup dependencies to keep `dist` lean. Refs STCON-145.
 
 ## [8.1.0](https://github.com/folio-org/stripes-connect/tree/v8.1.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v7.1.0...v8.1.0)

--- a/package.json
+++ b/package.json
@@ -74,8 +74,8 @@
     "prop-types": "^15.5.10",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-redux": "^8.0.5",
     "redux-observable": "^1.2.0",
+    "react-redux": "^8.0.5",
     "rxjs": "^6.6.3"
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-connect",
-  "version": "8.2.0",
+  "version": "8.2.29",
   "description": "Declarative REST data access for React components",
   "repository": "folio-org/stripes-connect",
   "sideEffects": [
@@ -75,7 +75,6 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-redux": "^8.0.5",
-    "redux": "^4.0.0",
     "redux-observable": "^1.2.0",
     "rxjs": "^6.6.3"
   },

--- a/package.json
+++ b/package.json
@@ -52,10 +52,13 @@
     "fetch-mock": "^9.10.1",
     "jsdom": "^17",
     "jsdom-global": "^3.0.2",
+    "lodash": "^4.17.11",
     "mocha": "^6.1.3",
     "node-fetch": "^2.6.1",
+    "prop-types": "^15.5.10",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "redux": "^4.0.0",
     "redux-observable": "^1.2.0",
     "react-redux": "^8.0.5",
     "redux-thunk": "^2.1.0",
@@ -63,17 +66,17 @@
     "rxjs": "^6.6.3"
   },
   "dependencies": {
-    "lodash": "^4.17.11",
-    "prop-types": "^15.5.10",
     "query-string": "^7.1.2",
-    "redux": "^4.0.0",
     "uuid": "^8.3.2"
   },
   "peerDependencies": {
+    "lodash": "^4.17.11",
+    "prop-types": "^15.5.10",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "redux-observable": "^1.2.0",
     "react-redux": "^8.0.5",
+    "redux": "^4.0.0",
+    "redux-observable": "^1.2.0",
     "rxjs": "^6.6.3"
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-connect",
-  "version": "8.2.29",
+  "version": "8.2.0",
   "description": "Declarative REST data access for React components",
   "repository": "folio-org/stripes-connect",
   "sideEffects": [

--- a/webpack.transpile.config.js
+++ b/webpack.transpile.config.js
@@ -1,13 +1,19 @@
+const externals = [
+  'react/jsx-runtime',
+  'rxjs/operators'
+];
+
 const config = {
-  externals: {
-    'react/jsx-runtime': {
-      root: 'react/jsx-runtime',
-      commonjs2: 'react/jsx-runtime',
-      commonjs: 'react/jsx-runtime',
-      amd: 'react/jsx-runtime',
-      umd: 'react/jsx-runtime'
-    }
-  }
+  externals: externals.reduce((acc, name) => {
+    acc[name] = {
+      root: name,
+      commonjs2: name,
+      commonjs: name,
+      amd: name,
+      umd: name
+    };
+    return acc;
+  }, {})
 };
 
 module.exports = config;

--- a/webpack.transpile.config.js
+++ b/webpack.transpile.config.js
@@ -1,19 +1,12 @@
 const config = {
   externals: {
-    rxjs: {
-      root: 'rxjs',
-      commonjs2: 'rxjs',
-      commonjs: 'rxjs',
-      amd: 'rxjs',
-      umd: 'rxjs'
-    },
-    'redux-observable': {
-      root: 'redux-observable',
-      commonjs2: 'redux-observable',
-      commonjs: 'redux-observable',
-      amd: 'redux-observable',
-      umd: 'redux-observable'
-    },
+    'react/jsx-runtime': {
+      root: 'react/jsx-runtime',
+      commonjs2: 'react/jsx-runtime',
+      commonjs: 'react/jsx-runtime',
+      amd: 'react/jsx-runtime',
+      umd: 'react/jsx-runtime'
+    }
   }
 };
 


### PR DESCRIPTION
https://issues.folio.org/browse/STCON-145

In order to keep the bundled dist lean we need to align the dependencies correctly.

All dependencies which should not be included in the dist should be moved under peer.

This cuts the final dist from 130KB to 37KB.

This PR should be merged after https://github.com/folio-org/stripes-webpack/pull/104