### PR TITLE
STCON-146 align redux semver with in-use version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Introduce transpilation. Fixes STCON-140.
 * Use `index.js` to correctly export public API. Refs STCON-144.
+* Use consistent version constraints on `redux` to guarantee a singleton. Refs STCON-146, STRIPES-860.
 
 ## [8.1.0](https://github.com/folio-org/stripes-connect/tree/v8.1.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v7.1.0...v8.1.0)

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "lodash": "^4.17.11",
     "prop-types": "^15.5.10",
     "query-string": "^7.1.2",
-    "redux": "^4.0.0",
+    "redux": "^4.2.1",
     "uuid": "^8.3.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
Align the semver constraint on redux with other portions of the platform (namely stripes and platform-complete) in order to guarantee a singleton and to facilitate the eventual move of this dependency to peer.

Refs [STCON-146](https://issues.folio.org/browse/STCON-146), [STRIPES-860](https://issues.folio.org/browse/STRIPES-860)