### PR TITLE
STCON-140 do not transpile

### DIFF
--- a/.github/workflows/build-npm-release.yml
+++ b/.github/workflows/build-npm-release.yml
@@ -206,9 +206,6 @@ jobs:
           echo ".scannerwork" >> .npmignore
           cat .npmignore
 
-      - name: Transpile module
-        run: npm run transpile
-
       - name: Publish NPM to FOLIO NPM registry
         run: npm publish
         env:

--- a/.github/workflows/build-npm.yml
+++ b/.github/workflows/build-npm.yml
@@ -152,10 +152,6 @@ jobs:
           echo ".scannerwork" >> .npmignore
           cat .npmignore
 
-      - name: Transpile module
-        if: ${{ github.ref == 'refs/heads/master' || github.ref  == 'refs/heads/main' }}
-        run: npm run transpile
-
       - name: Publish NPM
         if: ${{ github.ref == 'refs/heads/master' || github.ref  == 'refs/heads/main' }}
         run: npm publish

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
   "scripts": {
     "test": "nyc --reporter lcov --report-dir artifacts/coverage-jest mocha --require babel-test-hook --exit",
     "test-watch": "mocha --require babel-test-hook -w --watch-extensions json",
-    "lint": "eslint .",
-    "transpile": "stripes transpile"
+    "lint": "eslint ."
   },
   "devDependencies": {
     "@babel/core": "^7.8.0",


### PR DESCRIPTION
Short version of a long story: transpilation by itself offers no benefit, and transpiling and bundling (which is what the `stripes-cli transpile` command actually does at present) is not the appropriate at this level (only the leaf node of a JS app should be bundled; for us, that's the platform).

Refs [STCON-140](https://issues.folio.org/browse/STCON-140)