### PR TITLE
STCON-145 update deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ npm-debug.log
 yarn.lock
 yarn-error.log
 dist
+artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Introduce transpilation. Fixes STCON-140.
 * Use `index.js` to correctly export public API. Refs STCON-144.
+* Update outdated deps. Refs STCON-145.
 
 ## [8.1.0](https://github.com/folio-org/stripes-connect/tree/v8.1.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v7.1.0...v8.1.0)

--- a/package.json
+++ b/package.json
@@ -50,14 +50,13 @@
     "enzyme": "^3.3.0",
     "eslint": "^7.32.0",
     "fetch-mock": "^9.10.1",
-    "jsdom": "^17",
+    "jsdom": "^21.1.1",
     "jsdom-global": "^3.0.2",
-    "mocha": "^6.1.3",
-    "node-fetch": "^2.6.1",
+    "mocha": "^10.2.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "redux-observable": "^1.2.0",
     "react-redux": "^8.0.5",
+    "redux-observable": "^1.2.0",
     "redux-thunk": "^2.1.0",
     "regenerator-runtime": "^0.13.3",
     "rxjs": "^6.6.3"
@@ -67,13 +66,13 @@
     "prop-types": "^15.5.10",
     "query-string": "^7.1.2",
     "redux": "^4.0.0",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.0"
   },
   "peerDependencies": {
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "redux-observable": "^1.2.0",
     "react-redux": "^8.0.5",
+    "redux-observable": "^1.2.0",
     "rxjs": "^6.6.3"
   },
   "resolutions": {


### PR DESCRIPTION
Update the deps that can be updated painlessly. Those that remain are tricker:
* `query-string` has migrated to ESM only, which is great, except that it'll break the rest of the platform so until everybody migrates to jest-config-stripes where we can add a universal exception, we're not going to touch it here.
* `enzyme` and related things are woefully ancient but removing them would require a wholesale rewrite of the tests here. That may be worthwhile, but it's not gonna happen in the scope of this ticket.

Refs [STCON-145](https://issues.folio.org/browse/STCON-145)