### PR TITLE
STCON-140 finish transpile revert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## 8.2.0 IN PROGRESS
 
-* Introduce transpilation. Fixes STCON-140.
 * Use `index.js` to correctly export public API. Refs STCON-144.
 * Update outdated deps. Refs STCON-145.
 * Use consistent version constraints on `redux` to guarantee a singleton. Refs STCON-146, STRIPES-860.

--- a/package.json
+++ b/package.json
@@ -9,14 +9,7 @@
   "publishConfig": {
     "registry": "https://repository.folio.org/repository/npm-folio/"
   },
-  "main": "dist/index.js",
-  "files": [
-    "dist",
-    "README.md",
-    "LICENSE",
-    "CONTRIBUTING.md",
-    "CHANGELOG.md"
-  ],
+  "main": "index.js",
   "author": "Index Data",
   "license": "Apache-2.0",
   "engines": {


### PR DESCRIPTION
Transpile (STCON-140, PR #207) was partially reverted in PR #211 but I neglected to correctly revert `package.json`, which is now fixed here.

Refs [STCON-140](https://issues.folio.org/browse/STCON-140)