### PR TITLE
STCON-150 Support tenant override in okapi resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Use consistent version constraints on `redux` to guarantee a singleton. Refs STCON-146, STRIPES-860.
 * Import babel's test config via stripes-cli to keep consistent with settings in stripes-webpack. Refs STCON-148.
 * *BREAKING* Bump `react` to `18.2.0`. Refs STCON-147.
+* Support tenant override in okapi resources. Refs STCON-150.
 
 ## [8.1.0](https://github.com/folio-org/stripes-connect/tree/v8.1.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v7.1.0...v8.1.0)

--- a/OkapiResource.js
+++ b/OkapiResource.js
@@ -45,7 +45,7 @@ function optionsFromState(options, state) {
     const okapiOptions = {
       root: state.okapi.url,
       headers: {
-        'X-Okapi-Tenant': state.okapi.tenant,
+        'X-Okapi-Tenant': options.tenant || state.okapi.tenant,
         'Accept-Language': state.okapi.locale ?? 'en',
       },
     };

--- a/doc/api.md
+++ b/doc/api.md
@@ -214,6 +214,10 @@ configuration ensures that the correct tenant-ID is sent with each
 request, and that the `root` is defaulted to a globally-configured
 address pointing to an Okapi instance.)
 
+Okapi resources support extra configuration options:
+
+* `tenant`: A string that specifies tenant value or source of tenant value (props, query etc). This config is optional, if not specified default okapi tenant value is used.
+
 
 ### Example manifest
 

--- a/test/OkapiResource.js
+++ b/test/OkapiResource.js
@@ -1,0 +1,37 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import OkapiResource from '../OkapiResource';
+
+describe('OkapiResource', () => {
+  describe('optionsFromState', () => {
+    const okapiResource = new OkapiResource();
+    const optionsFromState = okapiResource.optionsFromState;
+
+    it('should return tenant from options', () => {
+      const options = {
+        type: 'okapi',
+        tenant: 'tenant1',
+      };
+      const state = {
+        okapi: {
+          url: 'url',
+          tenant: 'tenant2',
+        },
+      };
+
+      expect(optionsFromState(options, state).headers['X-Okapi-Tenant']).to.eql(options.tenant);
+    });
+
+    it('should return tenant from state if it does not exist in options', () => {
+      const options = { type: 'okapi' };
+      const state = {
+        okapi: {
+          tenant: 'tenant2',
+        },
+      };
+
+      expect(optionsFromState(options, state).headers['X-Okapi-Tenant']).to.eql(state.okapi.tenant);
+    });
+  });
+});


### PR DESCRIPTION
purpose: in scope of consortia work we need to fetch resources from different tenants, but there are some legacy class components that use manifests and stripes-connect. There is an option to override to hooks approach, but there are cases when it's required to override whole plugin (ui-plugin-find-user)

approach: introduce new optional okapi resource property to define tenant to be passed in headers. Usage can be reviewed in related PR

related to https://github.com/folio-org/ui-plugin-find-user/pull/238