### PR TITLE
STCON-138 handle access-control via cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Import babel's test config via stripes-cli to keep consistent with settings in stripes-webpack. Refs STCON-148.
 * *BREAKING* Bump `react` to `18.2.0`. Refs STCON-147.
 * Support tenant override in okapi resources. Refs STCON-150.
+* *BREAKING* Omit `X-Okapi-Token` request header; handle access-control via cookies. Refs STCON-138.
 
 ## [8.1.0](https://github.com/folio-org/stripes-connect/tree/v8.1.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v7.1.0...v8.1.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for stripes-connect
 
 ## 9.1.0 IN PROGRESS
+* Include auth-n related request headers. Refs STCON-138.
 
 ## [9.0.0](https://github.com/folio-org/stripes-connect/tree/v9.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v8.1.0...v9.0.0)
@@ -11,7 +12,6 @@
 * Import babel's test config via stripes-cli to keep consistent with settings in stripes-webpack. Refs STCON-148.
 * *BREAKING* Bump `react` to `18.2.0`. Refs STCON-147.
 * Support tenant override in okapi resources. Refs STCON-150.
-* *BREAKING* Omit `X-Okapi-Token` request header; handle access-control via cookies. Refs STCON-138.
 
 ## [8.1.0](https://github.com/folio-org/stripes-connect/tree/v8.1.0) (2023-01-30)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v7.1.0...v8.1.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change history for stripes-connect
 
 ## 9.1.0 IN PROGRESS
-* Include auth-n related request headers. Refs STCON-138.
+* Include auth-n related request options. Refs STCON-138.
 
 ## [9.0.0](https://github.com/folio-org/stripes-connect/tree/v9.0.0) (2023-10-11)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v8.1.0...v9.0.0)

--- a/OkapiResource.js
+++ b/OkapiResource.js
@@ -49,7 +49,6 @@ function optionsFromState(options, state) {
         'Accept-Language': state.okapi.locale ?? 'en',
       },
     };
-    if (state.okapi.token) okapiOptions.headers['X-Okapi-Token'] = state.okapi.token;
     return okapiOptions;
   }
   return {};

--- a/OkapiResource.js
+++ b/OkapiResource.js
@@ -49,6 +49,7 @@ function optionsFromState(options, state) {
         'Accept-Language': state.okapi.locale ?? 'en',
       },
     };
+    if (state.okapi.token) okapiOptions.headers['X-Okapi-Token'] = state.okapi.token;
     return okapiOptions;
   }
   return {};

--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -595,6 +595,8 @@ export default class RESTResource {
       headers,
       signal,
       body: JSON.stringify(remoteRecord),
+      credentials: 'include',
+      mode: 'cors',
     }).then((response) => {
       if (response.status >= 400) {
         const clonedResponse = response.clone();
@@ -656,6 +658,8 @@ export default class RESTResource {
         headers,
         signal,
         body: JSON.stringify(record),
+        credentials: 'include',
+        mode: 'cors',
       })
         .then((response) => {
           if (response.status >= 400) {
@@ -712,6 +716,8 @@ export default class RESTResource {
       method: 'DELETE',
       headers,
       signal,
+      credentials: 'include',
+      mode: 'cors',
     })
       .then((response) => {
         if (response.status >= 400) {
@@ -781,7 +787,7 @@ export default class RESTResource {
 
       const signal = this.addAbortController('fetch', options);
 
-      return fetch(url, { headers, signal })
+      return fetch(url, { headers, signal, credentials: 'include', mode: 'cors' })
         .then((response) => {
           if (response.status >= 400) {
             dispatch(this.fetchHTTPError(response));
@@ -853,7 +859,7 @@ export default class RESTResource {
 
       const signal = this.addAbortController('fetchPageByOffset', options);
 
-      return fetch(url, { headers, signal })
+      return fetch(url, { headers, signal, credentials: 'include', mode: 'cors' })
         .then((response) => {
           if (response.status >= 400) {
             dispatch(this.fetchHTTPError(response));
@@ -898,7 +904,7 @@ export default class RESTResource {
 
         const signal = this.addAbortController(`fetchMore${offset}`, options);
 
-        fetch(url, { headers, signal })
+        fetch(url, { headers, signal, credentials: 'include', mode: 'cors' })
           .then((response) => {
             if (response.status >= 400) {
               dispatch(this.fetchHTTPError(response));
@@ -954,7 +960,7 @@ export default class RESTResource {
 
       const signal = this.addAbortController('accFetch', options);
 
-      const beforeCatch = fetch(url, { headers, signal })
+      const beforeCatch = fetch(url, { headers, signal, credentials: 'include', mode: 'cors' })
         .then(response => response.text()
           .then((text) => {
             if (response.status >= 400) {


### PR DESCRIPTION
Handle access-control via cookies by way of the `Credentials: include` HTTP request option.

Refs [STCON-138](https://issues.folio.org/browse/STCON-138), [FOLIO-3627](https://issues.folio.org/browse/FOLIO-3627)