### PR TITLE
STCON-153 Apply `options` to override default values in PUT method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 9.2.0 IN PROGRESS
 
+* Apply `options` to override default values in PUT method. Refs STCON-153.
+
 ## [9.1.0](https://github.com/folio-org/stripes-connect/tree/v9.1.0) (2024-03-12)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v9.0.0...v9.1.0)
 

--- a/RESTResource/RESTResource.js
+++ b/RESTResource/RESTResource.js
@@ -644,7 +644,9 @@ export default class RESTResource {
     const clientRecord = { ...record };
 
     return (dispatch, getState) => {
-      const options = this.verbOptions('PUT', getState(), props);
+      let options = this.verbOptions('PUT', getState(), props);
+      options = Object.assign(options, opts);
+
       const { pk, headers } = options;
       const url = urlFromOptions(options, record[pk]);
       if (url === null) return null;


### PR DESCRIPTION
## Description
For Classification Browse feature in Inventory app we need to edit a config.
The endpoint that is used does not support `Accept: text/plain` header (default value) so we need some way to easily override defaults just for that Inventory setting.
`accFetch` that is used when calling `resource.GET` already has such ability, so I followed that pattern for `PUT` as well

## Issues
[STCON-153](https://folio-org.atlassian.net/browse/STCON-153)

## Related PRs
https://github.com/folio-org/stripes-smart-components/pull/1463
https://github.com/folio-org/ui-inventory/pull/2432