### PR TITLE
STCON-154 provide more lenient Accept values for PUT, DELETE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 9.2.0 IN PROGRESS
 
+* Provide more lenient defaults for `PUT`/`DELETE` `Accept` headers. Refs STCON-154.
+
 ## [9.1.0](https://github.com/folio-org/stripes-connect/tree/v9.1.0) (2024-03-12)
 [Full Changelog](https://github.com/folio-org/stripes-connect/compare/v9.0.0...v9.1.0)
 

--- a/OkapiResource.js
+++ b/OkapiResource.js
@@ -19,7 +19,7 @@ const defaults = {
   },
   DELETE: {
     headers: {
-      'Accept': 'text/plain',
+      'Accept': 'text/plain, application/json',
       'Content-Type': 'application/json',
     },
   },
@@ -31,7 +31,7 @@ const defaults = {
   },
   PUT: {
     headers: {
-      'Accept': 'text/plain',
+      'Accept': 'text/plain, application/json',
       'Content-Type': 'application/json',
     },
   },


### PR DESCRIPTION
Include `application/json` in the `Accept` header for `PUT` and `DELETE` responses in Okapi requests. This change does not represent a change in policy but rather brings the code into compliance with reality, where API requests may fail and provide JSON error messages. In fact, existing code already supports this (e.g. we inspect the content-type in `PUT` responses, which would be unnecessary if this convention were strictly followed). Many APIs likely do this, but we just didn't notice because they do not conduct content-type negotiations. New APIs with more strictly-compliant tooling do, however, and this default will allow UI code to use them without needing to override the too-strict default values.

Putting good defaults in one place feels better than permitting a strict default to be overridden and then having _lots_ of code that all uses the same override (cf. #229).

Refs [STCON-154](https://folio-org.atlassian.net/browse/STCON-154)