### PR TITLE
STCON-165 GA: omit publishing MD 

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -7,11 +7,13 @@ on:
 jobs:
   ui:
     uses: folio-org/.github/.github/workflows/ui.yml@v1.1
+    if: github.ref_name == github.event.repository.default_branch || github.event_name != 'push' || github.ref_type == 'tag'
     secrets: inherit
     with:
       jest-enabled: true
       jest-test-command: yarn run test
       sonar-sources: .
       compile-translations: false
-
+      generate-module-descriptor: false
+      publish-module-descriptor: false
 

--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   ui:
-    uses: folio-org/.github/.github/workflows/ui.yml@v1.1
+    uses: folio-org/.github/.github/workflows/ui.yml@v1.5
     if: github.ref_name == github.event.repository.default_branch || github.event_name != 'push' || github.ref_type == 'tag'
     secrets: inherit
     with:


### PR DESCRIPTION
There is no module descriptor here. Additionally, make this workflow
conditional to avoid running twice when GA logs multiple events for the
same action when opening a new PR.

Refs [STCON-165](https://folio-org.atlassian.net/browse/STCON-165), [STRIPES-938](https://folio-org.atlassian.net/browse/STRIPES-938)